### PR TITLE
FV-47: Fixed issue where unnexpected code was being called and breaki…

### DIFF
--- a/app/assets/javascripts/common/FormHelpers.js
+++ b/app/assets/javascripts/common/FormHelpers.js
@@ -25,7 +25,14 @@ export default {
             // Treat valued checkboxes differently. Always have value, so skip if unchecked.
             // getComponent does not work with input names that have '.' in them. Access directly.
             // valuedCheckbox = selectn('form.refs.input.refs[\'' + key + '\'].refs.valued_checkbox', form);
-            let valuedCheckbox = form.refs.input.refs[key].refs.valued_checkbox;
+            
+            let valuedCheckbox = null;
+
+            // Ensure Input for Form Ref is defined
+            if(form.refs.input)
+            {
+              valuedCheckbox = form.refs.input.refs[key].refs.valued_checkbox;  
+            }
 
             if (valuedCheckbox) {
                   if (!valuedCheckbox.checked) {

--- a/app/assets/javascripts/views/pages/search/index.js
+++ b/app/assets/javascripts/views/pages/search/index.js
@@ -142,7 +142,9 @@ export default class Search extends DataListView {
 			e.preventDefault();
 		}
 
-		let form = this.refs["search_form"];
+		//let form = this.refs["search_form"];
+		let form = this.refs.search_form;
+
 		let properties = FormHelpers.getProperties(form);
 
 		if (Object.keys(properties).length != 0) {


### PR DESCRIPTION
…ng the Search Side Bar.

A section of code in the FormHelpers.js file was assuming that an object existed and was causing an unexpected error. Extra statements were added to check if the object exists before proceeding. 