### PR TITLE
FV-119: Mobile display of word and Phrase on iPhone

### DIFF
--- a/app/assets/javascripts/common/ProviderHelpers.js
+++ b/app/assets/javascripts/common/ProviderHelpers.js
@@ -53,15 +53,17 @@ const proxiesKeys = [
 
 export default {
   getEntry: function (wordResults, path) {
-    if (!wordResults || wordResults.isEmpty() || !path)
+    if (!wordResults || wordResults.isEmpty() || !path) {
       return null;
+    }
 
     let result = wordResults.find(function(entry) {
         return entry.get('id') === path;
     });
 
-	if (result)
+    if (result) {
     	return result.toJS();
+    }
 
     return null;
   },

--- a/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/index.js
+++ b/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/index.js
@@ -31,6 +31,9 @@ import RaisedButton from 'material-ui/lib/raised-button';
 
 import FacetFilterList from 'views/components/Browsing/facet-filter-list';
 
+import {BrowserView, MobileView, isBrowser, isMobile} from 'react-device-detect';
+
+
 /**
 * Learn phrases
 */
@@ -96,7 +99,14 @@ export default class PageDialectLearnPhrases extends PageDialectLearnBase {
     const phraseListView = <PhraseListView filter={this.state.filterInfo} routeParams={this.props.routeParams} />;
 
     // Render kids view
-    if (isKidsTheme) {
+    if (isKidsTheme || isMobile) {
+
+      let pageSize = 4; // Items per Kids page
+
+      // Mobile but not Kids
+      if(!isKidsTheme && isMobile) {
+        pageSize = 10; // Items per page for mobile, but not Kids
+      }
 
       let kidsFilter = this.state.filterInfo.setIn(['currentAppliedFilter', 'kids'], ' AND fv:available_in_childrens_archive=1');
 
@@ -104,7 +114,7 @@ export default class PageDialectLearnPhrases extends PageDialectLearnBase {
 
               <div className="row">
                 <div className={classNames('col-xs-12', 'col-md-8', 'col-md-offset-2')}>
-                  {React.cloneElement(phraseListView, { gridListView: true, gridCols: 2, DEFAULT_PAGE_SIZE: 4, filter: kidsFilter })}
+                  {React.cloneElement(phraseListView, { gridListView: true, gridCols: 2, DEFAULT_PAGE_SIZE: pageSize, filter: kidsFilter })}
                 </div>
               </div>
 

--- a/app/assets/javascripts/views/pages/explore/dialect/learn/words/index.js
+++ b/app/assets/javascripts/views/pages/explore/dialect/learn/words/index.js
@@ -33,6 +33,8 @@ import RaisedButton from 'material-ui/lib/raised-button';
 
 import FacetFilterList from 'views/components/Browsing/facet-filter-list';
 
+import {BrowserView, MobileView, isBrowser, isMobile} from 'react-device-detect';
+
 /**
 * Learn words
 */
@@ -102,14 +104,23 @@ export default class PageDialectLearnWords extends PageDialectLearnBase {
     const wordListView = <WordListView filter={this.state.filterInfo} routeParams={this.props.routeParams} />;
 
     // Render kids view
-    if (isKidsTheme) {
+
+    // Or Mobile
+    if (isKidsTheme || isMobile) {
+
+      let pageSize = 8; // Items per Kids page
+
+      // Mobile but not Kids
+      if(!isKidsTheme && isMobile) {
+        pageSize = 10; // Items per page for mobile, but not Kids
+      }
 
       let kidsFilter = this.state.filterInfo.setIn(['currentAppliedFilter', 'kids'], ' AND fv:available_in_childrens_archive=1');
 
       return <PromiseWrapper renderOnError={true} computeEntities={computeEntities}>
             <div className="row">
               <div className={classNames('col-xs-12', 'col-md-8', 'col-md-offset-2')}>
-                {React.cloneElement(wordListView, { gridListView: true, DEFAULT_PAGE_SIZE: 8, filter: kidsFilter })}
+                {React.cloneElement(wordListView, { gridListView: true, DEFAULT_PAGE_SIZE: pageSize, filter: kidsFilter })}
               </div>
             </div>
       </PromiseWrapper>;


### PR DESCRIPTION
- Investigated Kids views for words and phrases.
- Implemented Kids views for words and phrases when viewing on mobile device while maintaining expected post count.
- Updated ProviderHelpers code style by replacing one liner shorthand IF statements with curly braces.
- Investigated fixing Loading Icon on Phrases page, and failed. Created new Issue for this.