### PR TITLE
Fixing ProviderHelpers.js > getDialectPathFromURLArray()

### DIFF
--- a/frontend/app/assets/javascripts/common/ProviderHelpers.js
+++ b/frontend/app/assets/javascripts/common/ProviderHelpers.js
@@ -16,23 +16,9 @@ limitations under the License.
 
 import Immutable, { List, Map } from 'immutable'
 import StringHelpers from './StringHelpers'
-
 import selectn from 'selectn'
 
-const toJSKeepId = function(js) {
-  return typeof js !== 'object' || js === null
-    ? js
-    : Array.isArray(js)
-      ? Immutable.Seq(js)
-        .map(toJSKeepId)
-        .toList()
-      : js.hasOwnProperty('id')
-        ? Immutable.Seq(js).toMap()
-        : Immutable.Seq(js)
-          .map(toJSKeepId)
-          .toMap()
-}
-
+// Used by replaceAllWorkspaceSectionKeys() & switchWorkspaceSectionKeys()
 const proxiesKeys = [
   {
     workspace: 'fv-word:categories',
@@ -60,12 +46,115 @@ const proxiesKeys = [
   },
 ]
 
-const getEntryFunc = function(wordResults, path) {
+// Will perform action only if the data is not found in store
+// @key - the key to look up (or set) in the store for this action/reducer
+// @action - the action to perform if nothing found in store.
+// @reducer - the reducer to look for
+function fetchIfMissing(key, action, reducer) {
+  if (!selectn('success', getEntry(reducer, key))) {
+    action(key)
+  }
+}
+
+function filtersToNXQL(filterArray) {
+  let nxqlFilterString = ''
+  const nxqlGroups = {}
+
+  const generateNXQLString = function generateNXQLString(nxql, appliedFilter) {
+    return nxql.replace(/\$\{value\}/g, appliedFilter)
+  }
+
+  for (const appliedFilterKey in filterArray) {
+    const ak = Object.assign({}, filterArray[appliedFilterKey])
+    if (ak && ak.hasOwnProperty('filterOptions') && ak.filterOptions && ak.filterOptions.hasOwnProperty('nxql')) {
+      if (ak.appliedFilter === true) ak.appliedFilter = 1
+      if (ak.appliedFilter === false) ak.appliedFilter = 0
+
+      if (!ak.filterOptions.hasOwnProperty('nxqlGroup')) {
+        nxqlFilterString +=
+          ' ' +
+          (ak.filterOptions.hasOwnProperty('operator') ? ak.filterOptions.operator : 'AND') +
+          ' ' +
+          generateNXQLString(ak.filterOptions.nxql, ak.appliedFilter)
+      } else {
+        if (
+          nxqlGroups.hasOwnProperty(ak.filterOptions.nxqlGroup) &&
+          nxqlGroups[ak.filterOptions.nxqlGroup].length > 0
+        ) {
+          nxqlGroups[ak.filterOptions.nxqlGroup].push(generateNXQLString(ak.filterOptions.nxql, ak.appliedFilter))
+        } else {
+          nxqlGroups[ak.filterOptions.nxqlGroup] = [generateNXQLString(ak.filterOptions.nxql, ak.appliedFilter)]
+        }
+      }
+    }
+  }
+
+  let appendGroupNXQL = ''
+
+  for (const key in nxqlGroups) {
+    appendGroupNXQL += ' AND (' + nxqlGroups[key].join(' OR ') + ')'
+  }
+
+  return nxqlFilterString + appendGroupNXQL
+}
+
+function getDialectGroups(aces = [], currentlyAssignedGroups = []) {
+  if (aces.length === 0) {
+    return {
+      all: null,
+      new: null,
+    }
+  }
+
+  // Generate list of groups this user can be added to
+  const allAvailableGroups = {}
+
+  // Generate list of all groups related to this dialect
+  const newAvailableGroups = {}
+
+  aces.forEach(function acesForEach(group, i) {
+    const groupArray = group.username.split('_')
+    if (group.username.match(/members|recorders|administrators/g) != null) {
+      const groupLabel = groupArray.map((group) => StringHelpers.toTitleCase(group)).join(' ')
+
+      allAvailableGroups[group.username] = groupLabel
+
+      // If user is not already a memeber of this group, add to new available groups
+      if (currentlyAssignedGroups.indexOf(group.username) === -1) {
+        newAvailableGroups[group.username] = groupLabel
+      }
+    }
+  })
+
+  return {
+    all: allAvailableGroups,
+    new: newAvailableGroups,
+  }
+}
+
+/*
+getDialectPathFromURLArray(urlArray)
+
+Extracts dialect path from url array.
+Returns null if not found
+*/
+function getDialectPathFromURLArray(urlArray) {
+  const index = urlArray.findIndex((el) => {
+    return el.match(/^FV$/)
+  })
+  if (index !== -1) {
+    const _url = urlArray.slice(index, index + 5)
+    return decodeURI(`/${_url.join('/')}`)
+  }
+  return null
+}
+
+function getEntry(wordResults, path) {
   if (!wordResults || wordResults.isEmpty() || !path) {
     return null
   }
 
-  const result = wordResults.find(function(entry) {
+  const result = wordResults.find(function wordResultsFind(entry) {
     return entry.get('id') === path
   })
 
@@ -75,195 +164,157 @@ const getEntryFunc = function(wordResults, path) {
 
   return null
 }
-
-export default {
-  getEntry: getEntryFunc,
-  // Will perform action only if the data is not found in store
-  // @key - the key to look up (or set) in the store for this action/reducer
-  // @action - the action to perform if nothing found in store.
-  // @reducer - the reducer to look for
-  fetchIfMissing: function(key, action, reducer) {
-    if (!selectn('success', getEntryFunc(reducer, key))) {
-      action(key)
+function hasExtendedGroup(extendedGroups, group) {
+  if (extendedGroups && extendedGroups.size > 0) {
+    if (
+      extendedGroups.findIndex(function extendedGroupsFindIndex(entry) {
+        return entry.get('name') === group
+      }) === -1
+    ) {
+      return false
     }
-  },
-  toJSKeepId: function(js) {
-    return toJSKeepId(js)
-  },
-  /*hasExtendedGroup: function (extendedGroups, group) {
+    return true
+  }
+  return false
+}
 
-      if (extendedGroups && extendedGroups.size > 0) {
-        if (extendedGroups.findIndex(function(entry) { return (entry.get('name') === group) }) === -1) {
-          return false;
-        } else {
-          return true;
-        }
-      }
-
-      return false;
-    },*/
-  isActiveRole: function(roles) {
-    if (roles && roles.length > 0) {
-      if (
-        roles.indexOf('Record') !== -1 ||
-        roles.indexOf('Approve') !== -1 ||
-        roles.indexOf('Manage') !== -1 ||
-        roles.indexOf('Member') !== -1
-      ) {
-        return true
-      }
-    }
-
-    return false
-  },
-  /**
-   * A site member is not associated with any specific dialect, but still has access to site for other functionality.
-   */
-  isSiteMember: function(groups) {
-    return groups && groups.length === 1 && groups[0] === 'members'
-  },
-  /**
-   * A site admin
-   */
-  isAdmin: function(computeLogin) {
-    const userGroups = selectn('response.properties.groups', computeLogin)
-    return userGroups && userGroups.indexOf('administrators') != -1
-  },
-  /**
-   * Recorder with Approval
-   */
-  isRecorderWithApproval: function(computeLogin) {
-    const extendedGroups = selectn('response.extendedGroups', computeLogin)
-    const extendGroupsFiltered = (extendedGroups || []).filter((group) => group.name === 'recorders_with_approval')
-    return extendGroupsFiltered.length > 0
-  },
-  /**
-   * Checks if a current user is parts of list of groups
-   */
-  isDialectMember: function(computeLogin, computeDialect) {
-    const userGroups = selectn('response.properties.groups', computeLogin)
-
-    let groupsToCheck = []
-    if (computeDialect && computeDialect.size > 0) {
-      const dialect = computeDialect.get(0).get('response')
-
-      if (dialect && dialect != undefined) {
-        groupsToCheck = selectn('contextParameters.acls[0].aces', dialect).map((a) => a.username)
-      }
-    }
-
-    if (!userGroups || !groupsToCheck) {
+function isActiveRole(roles) {
+  if (roles && roles.length > 0) {
+    if (
+      roles.indexOf('Record') !== -1 ||
+      roles.indexOf('Approve') !== -1 ||
+      roles.indexOf('Manage') !== -1 ||
+      roles.indexOf('Member') !== -1
+    ) {
       return true
     }
+  }
 
-    const arrayIntersection = userGroups.filter((value) => groupsToCheck.indexOf(value) !== -1)
+  return false
+}
 
-    return arrayIntersection.length >= 1
-  },
-  isDialectPath: function(windowPath) {
-    return windowPath.indexOf('/FV/Workspaces/Data/') !== -1
-  },
-  getDialectPathFromURLArray: function(url) {
-    return decodeURI(url.slice(1, 7).join('/'))
-  },
-  switchWorkspaceSectionKeys: function(workspaceKey, area) {
-    const row = proxiesKeys.find(function(mapping) {
-      return mapping.workspace === workspaceKey
-    })
+/**
+ * A site admin
+ */
+function isAdmin(computeLogin) {
+  const userGroups = selectn('response.properties.groups', computeLogin)
+  return userGroups && userGroups.indexOf('administrators') != -1
+}
 
-    if (row) {
-      if (area == 'sections') {
-        return row.section
-      }
-      return row.workspace
+/**
+ * Checks if a current user is parts of list of groups
+ */
+function isDialectMember(computeLogin, computeDialect) {
+  const userGroups = selectn('response.properties.groups', computeLogin)
+
+  let groupsToCheck = []
+  if (computeDialect && computeDialect.size > 0) {
+    const dialect = computeDialect.get(0).get('response')
+
+    if (dialect && dialect != undefined) {
+      groupsToCheck = selectn('contextParameters.acls[0].aces', dialect).map((a) => a.username)
     }
+  }
 
-    return workspaceKey
-  },
-  getDialectGroups: function(aces = [], currentlyAssignedGroups = []) {
-    if (aces.length === 0) {
-      return {
-        all: null,
-        new: null,
-      }
+  if (!userGroups || !groupsToCheck) {
+    return true
+  }
+
+  const arrayIntersection = userGroups.filter((value) => groupsToCheck.indexOf(value) !== -1)
+
+  return arrayIntersection.length >= 1
+}
+
+function isDialectPath(windowPath) {
+  return windowPath.indexOf('/FV/Workspaces/Data/') !== -1
+}
+
+/**
+ * Recorder with Approval
+ */
+function isRecorderWithApproval(computeLogin) {
+  const extendedGroups = selectn('response.extendedGroups', computeLogin)
+  const extendGroupsFiltered = (extendedGroups || []).filter((group) => group.name === 'recorders_with_approval')
+  return extendGroupsFiltered.length > 0
+}
+
+/**
+ * A site member is not associated with any specific dialect, but still has access to site for other functionality.
+ */
+function isSiteMember(groups) {
+  return groups && groups.length === 1 && groups[0] === 'members'
+}
+
+function replaceAllWorkspaceSectionKeys(string, area) {
+  const searchKey = area == 'sections' ? 'workspace' : 'section'
+  const replaceKey = area == 'sections' ? 'section' : 'workspace'
+
+  for (const proxyKey in proxiesKeys) {
+    string = string.replace(new RegExp(proxiesKeys[proxyKey][searchKey], 'g'), proxiesKeys[proxyKey][replaceKey])
+  }
+
+  return string
+}
+
+function switchWorkspaceSectionKeys(workspaceKey, area) {
+  const row = proxiesKeys.find(function proxiesKeysFind(mapping) {
+    return mapping.workspace === workspaceKey
+  })
+
+  if (row) {
+    if (area == 'sections') {
+      return row.section
     }
+    return row.workspace
+  }
 
-    // Generate list of groups this user can be added to
-    const allAvailableGroups = {}
+  return workspaceKey
+}
 
-    // Generate list of all groups related to this dialect
-    const newAvailableGroups = {}
+function toJSKeepId(js) {
+  // const toReturn = typeof js !== 'object' || js === null
+  // ? js
+  // : Array.isArray(js)
+  //   ? Immutable.Seq(js)
+  //     .map(toJSKeepId)
+  //     .toList()
+  //   : js.hasOwnProperty('id')
+  //     ? Immutable.Seq(js).toMap()
+  //     : Immutable.Seq(js)
+  //       .map(toJSKeepId)
+  //       .toMap()
+  // return toReturn
+  // Note: The following should be the same as the above nested ternary
+  if (typeof js !== 'object' || js === null) {
+    return js
+  } else if (Array.isArray(js)) {
+    return Immutable.Seq(js)
+      .map(toJSKeepId)
+      .toList()
+  } else if (js.hasOwnProperty('id')) {
+    return Immutable.Seq(js).toMap()
+  }
+  return Immutable.Seq(js)
+    .map(toJSKeepId)
+    .toMap()
+}
 
-    aces.forEach(function(group, i) {
-      const groupArray = group.username.split('_')
-      if (group.username.match(/members|recorders|administrators/g) != null) {
-        const groupLabel = groupArray.map((group) => StringHelpers.toTitleCase(group)).join(' ')
-
-        allAvailableGroups[group.username] = groupLabel
-
-        // If user is not already a memeber of this group, add to new available groups
-        if (currentlyAssignedGroups.indexOf(group.username) === -1) {
-          newAvailableGroups[group.username] = groupLabel
-        }
-      }
-    })
-
-    return {
-      all: allAvailableGroups,
-      new: newAvailableGroups,
-    }
-  },
-  replaceAllWorkspaceSectionKeys: function(string, area) {
-    const searchKey = area == 'sections' ? 'workspace' : 'section'
-    const replaceKey = area == 'sections' ? 'section' : 'workspace'
-
-    for (const proxyKey in proxiesKeys) {
-      string = string.replace(new RegExp(proxiesKeys[proxyKey][searchKey], 'g'), proxiesKeys[proxyKey][replaceKey])
-    }
-
-    return string
-  },
-  filtersToNXQL: function(filterArray) {
-    let nxqlFilterString = ''
-    const nxqlGroups = {}
-
-    const generateNXQLString = function(nxql, appliedFilter) {
-      return nxql.replace(/\$\{value\}/g, appliedFilter)
-    }
-
-    for (const appliedFilterKey in filterArray) {
-      const ak = Object.assign({}, filterArray[appliedFilterKey])
-      if (ak && ak.hasOwnProperty('filterOptions') && ak.filterOptions && ak.filterOptions.hasOwnProperty('nxql')) {
-        if (ak.appliedFilter === true) ak.appliedFilter = 1
-        if (ak.appliedFilter === false) ak.appliedFilter = 0
-
-        if (!ak.filterOptions.hasOwnProperty('nxqlGroup')) {
-          nxqlFilterString +=
-            ' ' +
-            (ak.filterOptions.hasOwnProperty('operator') ? ak.filterOptions.operator : 'AND') +
-            ' ' +
-            generateNXQLString(ak.filterOptions.nxql, ak.appliedFilter)
-        } else {
-          if (
-            nxqlGroups.hasOwnProperty(ak.filterOptions.nxqlGroup) &&
-            nxqlGroups[ak.filterOptions.nxqlGroup].length > 0
-          ) {
-            nxqlGroups[ak.filterOptions.nxqlGroup].push(generateNXQLString(ak.filterOptions.nxql, ak.appliedFilter))
-          } else {
-            nxqlGroups[ak.filterOptions.nxqlGroup] = [generateNXQLString(ak.filterOptions.nxql, ak.appliedFilter)]
-          }
-        }
-      }
-    }
-
-    let appendGroupNXQL = ''
-
-    for (const key in nxqlGroups) {
-      appendGroupNXQL += ' AND (' + nxqlGroups[key].join(' OR ') + ')'
-    }
-
-    return nxqlFilterString + appendGroupNXQL
-  },
+export default {
+  fetchIfMissing,
+  filtersToNXQL,
+  getEntry,
+  getDialectGroups,
+  getDialectPathFromURLArray,
+  // hasExtendedGroup,
+  isAdmin,
+  isActiveRole,
+  isDialectMember,
+  isDialectPath,
+  isRecorderWithApproval,
+  isSiteMember,
+  replaceAllWorkspaceSectionKeys,
+  switchWorkspaceSectionKeys,
+  toJSKeepId,
   regex: {
     QUERY_PARAMS: /\?(.*)/,
     ANYTHING_BUT_SLASH: '([^/]*)',

--- a/frontend/app/assets/javascripts/common/__tests__/ProviderHelpers.js
+++ b/frontend/app/assets/javascripts/common/__tests__/ProviderHelpers.js
@@ -1,0 +1,105 @@
+import ProviderHelpers from '../ProviderHelpers'
+const {
+  fetchIfMissing, // calls getEntry
+  filtersToNXQL,
+  getDialectGroups,
+  getDialectPathFromURLArray,
+  getEntry, // calls immutable's isEmpty & find
+  isAdmin,
+  isActiveRole,
+  isDialectMember,
+  isDialectPath,
+  isRecorderWithApproval,
+  isSiteMember,
+  replaceAllWorkspaceSectionKeys,
+  switchWorkspaceSectionKeys,
+  toJSKeepId,
+} = ProviderHelpers
+describe('ProviderHelpers', () => {
+  test('getDialectPathFromURLArray', () => {
+    // Structure: Arrange
+    const urlStrings = [
+      'nuxeo/app/explore/FV/Workspaces/Data/Athabascan/Dene/Dene/learn/words/create',
+      'nuxeo/app/v2/explore/FV/Workspaces/Data/Athabascan/Dene/Dene/learn/words/create',
+      'explore/FV/Workspaces/Data/Athabascan/Dene/Dene/learn/words/create',
+      'FV/Workspaces/Data/Athabascan/Dene/Dene/learn/words/create',
+      'nuxeo/app/explore/FVGames/Workspaces/Data/Athabascan/Dene/Dene/learn/words/create',
+      'nuxeo/app/v2/explore/FVGames/Workspaces/Data/Athabascan/Dene/Dene/learn/words/create',
+      'explore/FVGames/Workspaces/Data/Athabascan/Dene/Dene/learn/words/create',
+      'FVGames/Workspaces/Data/Athabascan/Dene/Dene/learn/words/create',
+
+      'nuxeo/app/explore/FV/Workspaces/Data/SEN%C4%86O%C5%A6EN/SEN%C4%86O%C5%A6EN/SEN%C4%86O%C5%A6EN/learn/words/create',
+      'nuxeo/app/v2/explore/FV/Workspaces/Data/SEN%C4%86O%C5%A6EN/SEN%C4%86O%C5%A6EN/SEN%C4%86O%C5%A6EN/learn/words/create',
+      'explore/FV/Workspaces/Data/SEN%C4%86O%C5%A6EN/SEN%C4%86O%C5%A6EN/SEN%C4%86O%C5%A6EN/learn/words/create',
+      'FV/Workspaces/Data/SEN%C4%86O%C5%A6EN/SEN%C4%86O%C5%A6EN/SEN%C4%86O%C5%A6EN/learn/words/create',
+      'nuxeo/app/explore/FVGames/Workspaces/Data/SEN%C4%86O%C5%A6EN/SEN%C4%86O%C5%A6EN/SEN%C4%86O%C5%A6EN/learn/words/create',
+      'nuxeo/app/v2/explore/FVGames/Workspaces/Data/SEN%C4%86O%C5%A6EN/SEN%C4%86O%C5%A6EN/SEN%C4%86O%C5%A6EN/learn/words/create',
+      'explore/FVGames/Workspaces/Data/SEN%C4%86O%C5%A6EN/SEN%C4%86O%C5%A6EN/SEN%C4%86O%C5%A6EN/learn/words/create',
+      'FVGames/Workspaces/Data/SEN%C4%86O%C5%A6EN/SEN%C4%86O%C5%A6EN/SEN%C4%86O%C5%A6EN/learn/words/create',
+
+      'nuxeo/app/explore/FV/Workspaces/Data/daniel-test/daniel-test/daniel-test/learn/words/create',
+      'nuxeo/app/v2/explore/FV/Workspaces/Data/daniel-test/daniel-test/daniel-test/learn/words/create',
+      'explore/FV/Workspaces/Data/daniel-test/daniel-test/daniel-test/learn/words/create',
+      'FV/Workspaces/Data/daniel-test/daniel-test/daniel-test/learn/words/create',
+      'nuxeo/app/explore/FVGames/Workspaces/Data/daniel-test/daniel-test/daniel-test/learn/words/create',
+      'nuxeo/app/v2/explore/FVGames/Workspaces/Data/daniel-test/daniel-test/daniel-test/learn/words/create',
+      'explore/FVGames/Workspaces/Data/daniel-test/daniel-test/daniel-test/learn/words/create',
+      'FVGames/Workspaces/Data/daniel-test/daniel-test/daniel-test/learn/words/create',
+
+      'nuxeo/app/explore/FV/Workspaces/Data/mariana_test/mariana-test/dialect-mariana/learn/words/create',
+      'nuxeo/app/v2/explore/FV/Workspaces/Data/mariana_test/mariana-test/dialect-mariana/learn/words/create',
+      'explore/FV/Workspaces/Data/mariana_test/mariana-test/dialect-mariana/learn/words/create',
+      'FV/Workspaces/Data/mariana_test/mariana-test/dialect-mariana/learn/words/create',
+      'nuxeo/app/explore/FVGames/Workspaces/Data/mariana_test/mariana-test/dialect-mariana/learn/words/create',
+      'nuxeo/app/v2/explore/FVGames/Workspaces/Data/mariana_test/mariana-test/dialect-mariana/learn/words/create',
+      'explore/FVGames/Workspaces/Data/mariana_test/mariana-test/dialect-mariana/learn/words/create',
+      'FVGames/Workspaces/Data/mariana_test/mariana-test/dialect-mariana/learn/words/create',
+    ]
+    const correctAnswers = [
+      '/FV/Workspaces/Data/Athabascan/Dene',
+      '/FV/Workspaces/Data/Athabascan/Dene',
+      '/FV/Workspaces/Data/Athabascan/Dene',
+      '/FV/Workspaces/Data/Athabascan/Dene',
+      null,
+      null,
+      null,
+      null,
+
+      '/FV/Workspaces/Data/SEN%C4%86O%C5%A6EN/SEN%C4%86O%C5%A6EN',
+      '/FV/Workspaces/Data/SEN%C4%86O%C5%A6EN/SEN%C4%86O%C5%A6EN',
+      '/FV/Workspaces/Data/SEN%C4%86O%C5%A6EN/SEN%C4%86O%C5%A6EN',
+      '/FV/Workspaces/Data/SEN%C4%86O%C5%A6EN/SEN%C4%86O%C5%A6EN',
+      null,
+      null,
+      null,
+      null,
+
+      '/FV/Workspaces/Data/daniel-test/daniel-test',
+      '/FV/Workspaces/Data/daniel-test/daniel-test',
+      '/FV/Workspaces/Data/daniel-test/daniel-test',
+      '/FV/Workspaces/Data/daniel-test/daniel-test',
+      null,
+      null,
+      null,
+      null,
+
+      '/FV/Workspaces/Data/mariana_test/mariana-test',
+      '/FV/Workspaces/Data/mariana_test/mariana-test',
+      '/FV/Workspaces/Data/mariana_test/mariana-test',
+      '/FV/Workspaces/Data/mariana_test/mariana-test',
+      null,
+      null,
+      null,
+      null,
+    ]
+
+    urlStrings.forEach((urlString, index) => {
+      // fn() expects array, convert str to arr
+      const urlArray = urlString.split('/')
+      const output = getDialectPathFromURLArray(urlArray)
+
+      const answer = correctAnswers[index]
+      expect(output).toBe(answer)
+    })
+  })
+})


### PR DESCRIPTION
Includes jest test but this branch isn't currently setup to support jest tests (it's supported in the `jest-integration` branch).

FROM:
```
  getDialectPathFromURLArray: function(url) {
    return decodeURI(url.slice(1, 7).join('/'))
  },
```

TO:
```
/*
getDialectPathFromURLArray(urlArray)

Extracts dialect path from url array.
Returns null if not found
*/
function getDialectPathFromURLArray(urlArray) {
  const index = urlArray.findIndex((el) => {
    return el.match(/^FV$/)
  })
  if (index !== -1) {
    const _url = urlArray.slice(index, index + 5)
    return decodeURI(`/${_url.join('/')}`)
  }
  return null
}
```

Note: `ProviderHelpers.js` has been reorganized to have the fns() outside of the exported object