### PR TITLE
FW-650 Change Cypress tests to use a single password

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -172,28 +172,14 @@ These Cypress tests require that you have java and maven installed as well as th
 
 For the database setup scripts:
 ```
-CYPRESS_FV_ADMIN_USERNAME
-CYPRESS_FV_ADMIN_PASSWORD
+CYPRESS_FV_USERNAME
+CYPRESS_FV_PASSWORD
 ```
 
 For recording runs (optional):
 ```
 CYPRESS_PROJECT_ID
 CYPRESS_RECORD_KEY
-```
-
-Additionally you will need to set environment variables for all of the users of the test languages (language admins, members, recorders, recorders with approval).
-
-Example: For TestLanguageOne you would set (must be repeated for language Two to Six):
-```
-CYPRESS_TESTLANGUAGEONE_MEMBER_USERNAME
-CYPRESS_TESTLANGUAGEONE_MEMBER_PASSWORD
-CYPRESS_TESTLANGUAGEONE_RECORDER_USERNAME
-CYPRESS_TESTLANGUAGEONE_RECORDER_PASSWORD
-CYPRESS_TESTLANGUAGEONE_RECORDER_APPROVER_USERNAME
-CYPRESS_TESTLANGUAGEONE_RECORDER_APPROVER_PASSWORD
-CYPRESS_TESTLANGUAGEONE_ADMIN_USERNAME
-CYPRESS_TESTLANGUAGEONE_ADMIN_PASSWORD
 ```
 
 ### Frontend: Unit testing

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/ExploreDialectEdit/__cypress__/LangAdminPortal-Inline.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/ExploreDialectEdit/__cypress__/LangAdminPortal-Inline.js
@@ -7,9 +7,7 @@ describe('LangAdminPortal-Inline.js > LangAdminPortal-Inline', () => {
             Login as Language Admin.
         */
     cy.login({
-      userName: 'TESTLANGUAGEONE_ADMIN_USERNAME',
-      userPassword: 'TESTLANGUAGEONE_ADMIN_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEONE_ADMIN',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageOne')
     cy.wait(500)

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/ExploreDialectEdit/__cypress__/LangAdminPortal.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/ExploreDialectEdit/__cypress__/LangAdminPortal.js
@@ -7,9 +7,7 @@ describe('LangAdminPortal.js > LangAdminPortal', () => {
                         Login as Language Admin and navigate to the edit portal page.
                     */
     cy.login({
-      userName: 'TESTLANGUAGETWO_ADMIN_USERNAME',
-      userPassword: 'TESTLANGUAGETWO_ADMIN_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGETWO_ADMIN',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageTwo')
 

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/Phrasebook/__cypress__/PhrasebookCreate.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/Phrasebook/__cypress__/PhrasebookCreate.js
@@ -10,9 +10,7 @@ describe('PhrasebookCreate.js > Phrasebook', () => {
   it('Create', () => {
     // Login
     cy.login({
-      userName: 'TESTLANGUAGETWO_RECORDER_USERNAME',
-      userPassword: 'TESTLANGUAGETWO_RECORDER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGETWO_RECORDER',
     })
 
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageTwo/create/phrasebook')

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/__cypress__/LangAdminCreateDelete-Phrase.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/__cypress__/LangAdminCreateDelete-Phrase.js
@@ -13,9 +13,7 @@ describe('LangAdminCreateDelete-Phrase.js > LangAdminCreateDelete-Phrase', () =>
                 Login as Language Admin and check that no phrases currently exists.
             */
     cy.login({
-      userName: 'TESTLANGUAGEONE_ADMIN_USERNAME',
-      userPassword: 'TESTLANGUAGEONE_ADMIN_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEONE_ADMIN',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageOne/learn/phrases')
     cy.getByText('No results found.', { exact: true }).should('be.visible')

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/__cypress__/LangAdminViewEdit-Phrase.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/__cypress__/LangAdminViewEdit-Phrase.js
@@ -13,9 +13,7 @@ describe('LangAdminViewEdit-Phrase.js > LangAdminViewEdit-Phrase', () => {
             Login as member and check that the phrase is not visible.
          */
     cy.login({
-      userName: 'TESTLANGUAGETWO_MEMBER_USERNAME',
-      userPassword: 'TESTLANGUAGETWO_MEMBER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGETWO_MEMBER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageTwo')
     cy.getByText('Learn our Language', { exact: true }).click()
@@ -31,9 +29,7 @@ describe('LangAdminViewEdit-Phrase.js > LangAdminViewEdit-Phrase', () => {
                 Login as Language Admin, navigate to phrases and check that a phrase exists.
             */
     cy.login({
-      userName: 'TESTLANGUAGETWO_ADMIN_USERNAME',
-      userPassword: 'TESTLANGUAGETWO_ADMIN_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGETWO_ADMIN',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageTwo')
     cy.getByText('Learn our Language', { exact: true }).click()
@@ -67,9 +63,7 @@ describe('LangAdminViewEdit-Phrase.js > LangAdminViewEdit-Phrase', () => {
             Login as member and check that the phrase is now visible and enabled.
          */
     cy.login({
-      userName: 'TESTLANGUAGETWO_MEMBER_USERNAME',
-      userPassword: 'TESTLANGUAGETWO_MEMBER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGETWO_MEMBER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageTwo')
     cy.getByText('Learn our Language', { exact: true }).click()
@@ -88,9 +82,7 @@ describe('LangAdminViewEdit-Phrase.js > LangAdminViewEdit-Phrase', () => {
             Login as Language Admin and publish the phrase.
          */
     cy.login({
-      userName: 'TESTLANGUAGETWO_ADMIN_USERNAME',
-      userPassword: 'TESTLANGUAGETWO_ADMIN_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGETWO_ADMIN',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageTwo/learn/phrases')
     cy.wait(800)

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/__cypress__/MemberView-Phrase.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/__cypress__/MemberView-Phrase.js
@@ -14,9 +14,7 @@ describe('MemberView-Phrase.js > MemberView-Phrase', () => {
             Login as Language Member, navigate to phrases and check that a phrase exists.
         */
     cy.login({
-      userName: 'TESTLANGUAGEFIVE_MEMBER_USERNAME',
-      userPassword: 'TESTLANGUAGEFIVE_MEMBER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFIVE_MEMBER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFive')
     cy.wait(500)

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/__cypress__/RecApprovalCreateDelete-Phrase.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/__cypress__/RecApprovalCreateDelete-Phrase.js
@@ -13,9 +13,7 @@ describe('RecApprovalCreateDelete-Phrase.js > RecApprovalCreateDelete-Phrase', (
                     Login as Recorder with Approval and check that no phrases currently exists.
                 */
     cy.login({
-      userName: 'TESTLANGUAGETHREE_RECORDER_APPROVER_USERNAME',
-      userPassword: 'TESTLANGUAGETHREE_RECORDER_APPROVER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGETHREE_RECORDER_APPROVER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageThree/learn/phrases')
     cy.getByText('No results found.', { exact: true }).should('be.visible')

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/__cypress__/RecorderCreate-Phrase.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/__cypress__/RecorderCreate-Phrase.js
@@ -7,9 +7,7 @@ describe('RecorderCreate-Phrase.js > RecorderCreate-Phrase', () => {
                 Login as Recorder, go to phrase creation page and click create new phrase
             */
     cy.login({
-      userName: 'TESTLANGUAGEFOUR_RECORDER_USERNAME',
-      userPassword: 'TESTLANGUAGEFOUR_RECORDER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFOUR_RECORDER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFour')
     cy.getByText('Learn our Language', { exact: true }).click()
@@ -107,9 +105,7 @@ describe('RecorderCreate-Phrase.js > RecorderCreate-Phrase', () => {
             Check that the phrase is not visible for Site Member when not enabled
          */
     cy.login({
-      userName: 'SITE_MEMBER_USERNAME',
-      userPassword: 'SITE_MEMBER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'SITE_MEMBER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFour/learn/phrases')
     cy.queryByText('TestPhrase').should('not.exist')
@@ -124,9 +120,7 @@ describe('RecorderCreate-Phrase.js > RecorderCreate-Phrase', () => {
             Login as admin and enable the phrase
          */
     cy.login({
-      userName: 'TESTLANGUAGEFOUR_ADMIN_USERNAME',
-      userPassword: 'TESTLANGUAGEFOUR_ADMIN_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFOUR_ADMIN',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFour/learn/phrases')
     cy.wait(800)
@@ -142,9 +136,7 @@ describe('RecorderCreate-Phrase.js > RecorderCreate-Phrase', () => {
               Login as language member and check that the story is now visible.
            */
     cy.login({
-      userName: 'TESTLANGUAGEFOUR_MEMBER_USERNAME',
-      userPassword: 'TESTLANGUAGEFOUR_MEMBER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFOUR_MEMBER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFour/learn/phrases')
     cy.getByTestId('DictionaryList__row').within(() => {
@@ -159,9 +151,7 @@ describe('RecorderCreate-Phrase.js > RecorderCreate-Phrase', () => {
                 Login as admin and publish the phrase.
              */
     cy.login({
-      userName: 'TESTLANGUAGEFOUR_ADMIN_USERNAME',
-      userPassword: 'TESTLANGUAGEFOUR_ADMIN_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFOUR_ADMIN',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFour/learn/phrases')
     cy.wait(500)

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/songs-stories/__cypress__/LangAdminCreateDelete-Song.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/songs-stories/__cypress__/LangAdminCreateDelete-Song.js
@@ -7,9 +7,7 @@ describe('LangAdminCreateDelete-Song.js > LangAdminCreateDelete-Song', () => {
                     Login as Language Admin and check that no songs currently exists.
                 */
     cy.login({
-      userName: 'TESTLANGUAGEONE_ADMIN_USERNAME',
-      userPassword: 'TESTLANGUAGEONE_ADMIN_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEONE_ADMIN',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageOne/learn/songs')
     cy.queryByText('TestSongTitle').should('not.exist')

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/songs-stories/__cypress__/LangAdminCreateDelete-Story.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/songs-stories/__cypress__/LangAdminCreateDelete-Story.js
@@ -7,9 +7,7 @@ describe('LangAdminCreateDelete-Story.js > LangAdminCreateDelete-Story', () => {
                         Login as Language Admin and check that no stories currently exists.
                     */
     cy.login({
-      userName: 'TESTLANGUAGEONE_ADMIN_USERNAME',
-      userPassword: 'TESTLANGUAGEONE_ADMIN_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEONE_ADMIN',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageOne/learn/stories')
     cy.queryByText('TestStoryTitle').should('not.exist')

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/songs-stories/__cypress__/RecApprovalCreateDelete-Song.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/songs-stories/__cypress__/RecApprovalCreateDelete-Song.js
@@ -7,9 +7,7 @@ describe('RecApprovalCreateDelete-Song.js > RecApprovalCreateDelete-Song', () =>
                         Login as Recorder with Approval and check that no songs currently exists.
                     */
     cy.login({
-      userName: 'TESTLANGUAGETHREE_RECORDER_APPROVER_USERNAME',
-      userPassword: 'TESTLANGUAGETHREE_RECORDER_APPROVER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGETHREE_RECORDER_APPROVER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageThree/learn/songs')
     cy.wait(500)

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/songs-stories/__cypress__/RecApprovalCreateDelete-Story.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/songs-stories/__cypress__/RecApprovalCreateDelete-Story.js
@@ -7,9 +7,7 @@ describe('RecApprovalCreateDelete-Story.js > RecApprovalCreateDelete-Stories', (
                             Login as Recorder with Approval and check that no stories currently exists.
                         */
     cy.login({
-      userName: 'TESTLANGUAGETHREE_RECORDER_APPROVER_USERNAME',
-      userPassword: 'TESTLANGUAGETHREE_RECORDER_APPROVER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGETHREE_RECORDER_APPROVER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageThree/learn/stories')
     cy.wait(500)

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/songs-stories/__cypress__/RecorderCreate-Song.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/songs-stories/__cypress__/RecorderCreate-Song.js
@@ -7,9 +7,7 @@ describe('RecorderCreate-Song.js > RecorderCreate-Song', () => {
             Login as Recorder and check that no songs exist.
         */
     cy.login({
-      userName: 'TESTLANGUAGEFOUR_RECORDER_USERNAME',
-      userPassword: 'TESTLANGUAGEFOUR_RECORDER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFOUR_RECORDER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFour')
     cy.getByText('Learn our Language', { exact: true }).click()
@@ -134,9 +132,7 @@ describe('RecorderCreate-Song.js > RecorderCreate-Song', () => {
             Login as language member and check that the song is not visible.
          */
     cy.login({
-      userName: 'TESTLANGUAGEFOUR_MEMBER_USERNAME',
-      userPassword: 'TESTLANGUAGEFOUR_MEMBER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFOUR_MEMBER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFour/learn/songs')
     cy.queryByText('TestSongTitle').should('not.exist')
@@ -147,9 +143,7 @@ describe('RecorderCreate-Song.js > RecorderCreate-Song', () => {
             Login as admin, check that the song is editable, and enable the song.
          */
     cy.login({
-      userName: 'TESTLANGUAGEFOUR_ADMIN_USERNAME',
-      userPassword: 'TESTLANGUAGEFOUR_ADMIN_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFOUR_ADMIN',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFour/learn/songs')
     cy.queryByText('TestSongTitle')
@@ -187,9 +181,7 @@ describe('RecorderCreate-Song.js > RecorderCreate-Song', () => {
             Login as language member and check that the song is now visible.
          */
     cy.login({
-      userName: 'TESTLANGUAGEFOUR_MEMBER_USERNAME',
-      userPassword: 'TESTLANGUAGEFOUR_MEMBER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFOUR_MEMBER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFour/learn/songs')
     cy.getByTestId('pageContainer').within(() => {
@@ -204,9 +196,7 @@ describe('RecorderCreate-Song.js > RecorderCreate-Song', () => {
             Login as admin and publish the song.
          */
     cy.login({
-      userName: 'TESTLANGUAGEFOUR_ADMIN_USERNAME',
-      userPassword: 'TESTLANGUAGEFOUR_ADMIN_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFOUR_ADMIN',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFour/learn/songs')
     cy.queryByText('TestSongTitleEdited')

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/songs-stories/__cypress__/RecorderCreate-Story.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/songs-stories/__cypress__/RecorderCreate-Story.js
@@ -7,9 +7,7 @@ describe('RecorderCreate-Story.js > RecorderCreate-Story', () => {
                 Login as Recorder and check that no stories exist.
             */
     cy.login({
-      userName: 'TESTLANGUAGEFOUR_RECORDER_USERNAME',
-      userPassword: 'TESTLANGUAGEFOUR_RECORDER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFOUR_RECORDER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFour')
     cy.getByText('Learn our Language', { exact: true }).click()
@@ -134,9 +132,7 @@ describe('RecorderCreate-Story.js > RecorderCreate-Story', () => {
                 Login as language member and check that the story is not visible.
              */
     cy.login({
-      userName: 'TESTLANGUAGEFOUR_MEMBER_USERNAME',
-      userPassword: 'TESTLANGUAGEFOUR_MEMBER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFOUR_MEMBER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFour/learn/stories')
     cy.queryByText('TestStoryTitle').should('not.exist')
@@ -147,9 +143,7 @@ describe('RecorderCreate-Story.js > RecorderCreate-Story', () => {
                 Login as admin, check that the story is editable, and enable the story.
              */
     cy.login({
-      userName: 'TESTLANGUAGEFOUR_ADMIN_USERNAME',
-      userPassword: 'TESTLANGUAGEFOUR_ADMIN_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFOUR_ADMIN',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFour/learn/stories')
     cy.queryByText('TestStoryTitle')
@@ -187,9 +181,7 @@ describe('RecorderCreate-Story.js > RecorderCreate-Story', () => {
                 Login as language member and check that the story is now visible.
              */
     cy.login({
-      userName: 'TESTLANGUAGEFOUR_MEMBER_USERNAME',
-      userPassword: 'TESTLANGUAGEFOUR_MEMBER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFOUR_MEMBER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFour/learn/stories')
     cy.getByTestId('pageContainer').within(() => {
@@ -204,9 +196,7 @@ describe('RecorderCreate-Story.js > RecorderCreate-Story', () => {
                 Login as admin and publish the story.
              */
     cy.login({
-      userName: 'TESTLANGUAGEFOUR_ADMIN_USERNAME',
-      userPassword: 'TESTLANGUAGEFOUR_ADMIN_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFOUR_ADMIN',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFour/learn/stories')
     cy.queryByText('TestStoryTitleEdited')

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/__cypress__/LangAdminCreateDelete-Word.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/__cypress__/LangAdminCreateDelete-Word.js
@@ -13,9 +13,7 @@ describe('LangAdminCreateDelete-Word.js > LangAdminCreateDelete-Word', () => {
             Login as Language Admin and check that no word currently exists.
         */
     cy.login({
-      userName: 'TESTLANGUAGEONE_ADMIN_USERNAME',
-      userPassword: 'TESTLANGUAGEONE_ADMIN_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEONE_ADMIN',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageOne/learn/words')
     cy.getByText('No results found.', { exact: true }).should('be.visible')

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/__cypress__/LangAdminViewEdit-Word.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/__cypress__/LangAdminViewEdit-Word.js
@@ -13,9 +13,7 @@ describe('LangAdminViewEdit-Word.js > LangAdminViewEdit-Word', () => {
             Login as Language Member and check that the word is not visible when not enabled.
         */
     cy.login({
-      userName: 'TESTLANGUAGETWO_MEMBER_USERNAME',
-      userPassword: 'TESTLANGUAGETWO_MEMBER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGETWO_MEMBER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageTwo')
     cy.getByText('Learn our Language', { exact: true }).click()
@@ -30,9 +28,7 @@ describe('LangAdminViewEdit-Word.js > LangAdminViewEdit-Word', () => {
                 Login as Language Admin, navigate to words and check that a word exists.
             */
     cy.login({
-      userName: 'TESTLANGUAGETWO_ADMIN_USERNAME',
-      userPassword: 'TESTLANGUAGETWO_ADMIN_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGETWO_ADMIN',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageTwo')
     cy.getByText('Learn our Language', { exact: true }).click()
@@ -68,9 +64,7 @@ describe('LangAdminViewEdit-Word.js > LangAdminViewEdit-Word', () => {
             Login as member and check that the word is now visible and enabled.
          */
     cy.login({
-      userName: 'TESTLANGUAGETWO_MEMBER_USERNAME',
-      userPassword: 'TESTLANGUAGETWO_MEMBER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGETWO_MEMBER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageTwo')
     cy.getByText('Learn our Language', { exact: true }).click()
@@ -89,9 +83,7 @@ describe('LangAdminViewEdit-Word.js > LangAdminViewEdit-Word', () => {
             Login as Admin and publish the word.
         */
     cy.login({
-      userName: 'TESTLANGUAGETWO_ADMIN_USERNAME',
-      userPassword: 'TESTLANGUAGETWO_ADMIN_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGETWO_ADMIN',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageTwo/learn/words')
     cy.wait(800)

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/__cypress__/MemberVisibility-Word.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/__cypress__/MemberVisibility-Word.js
@@ -14,9 +14,7 @@ describe('MemberVisibility-Word.js > MemberVisibility-Word', () => {
             Login as Member
         */
     cy.login({
-      userName: 'TESTLANGUAGEFIVE_MEMBER_USERNAME',
-      userPassword: 'TESTLANGUAGEFIVE_MEMBER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFIVE_MEMBER',
     })
     /*
             Check that edit button does not exist and go to reports page

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/__cypress__/RecApprovalCreateDelete-Word.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/__cypress__/RecApprovalCreateDelete-Word.js
@@ -13,9 +13,7 @@ describe('RecApprovalCreateDelete-Word.js > RecApprovalCreateDelete-Word', () =>
                 Login as Recorder with approval and check that no word currently exists.
             */
     cy.login({
-      userName: 'TESTLANGUAGETHREE_RECORDER_APPROVER_USERNAME',
-      userPassword: 'TESTLANGUAGETHREE_RECORDER_APPROVER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGETHREE_RECORDER_APPROVER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageThree/learn/words')
     cy.getByText('No results found.', { exact: true }).should('be.visible')

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/__cypress__/RecorderCreate-Word.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/__cypress__/RecorderCreate-Word.js
@@ -4,9 +4,7 @@
 describe('RecorderCreate-Word.js > RecorderCreate-Word', () => {
   it('Test to check recorder word creation functionality.', () => {
     cy.login({
-      userName: 'TESTLANGUAGEFOUR_RECORDER_USERNAME',
-      userPassword: 'TESTLANGUAGEFOUR_RECORDER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFOUR_RECORDER',
     })
 
     /*

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/__cypress__/RecorderEnable-Word.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/__cypress__/RecorderEnable-Word.js
@@ -10,9 +10,7 @@ describe('RecorderEnable-Word.js > RecorderEnable-Word', () => {
     cy.wait(500)
 
     cy.login({
-      userName: 'TESTLANGUAGEFIVE_RECORDER_USERNAME',
-      userPassword: 'TESTLANGUAGEFIVE_RECORDER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFIVE_RECORDER',
     })
 
     /*
@@ -44,9 +42,7 @@ describe('RecorderEnable-Word.js > RecorderEnable-Word', () => {
       Login as Admin and verify task exists / reject task.
     */
     cy.login({
-      userName: 'TESTLANGUAGEFIVE_ADMIN_USERNAME',
-      userPassword: 'TESTLANGUAGEFIVE_ADMIN_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFIVE_ADMIN',
     })
     cy.reload()
     cy.wait(500)
@@ -60,9 +56,7 @@ describe('RecorderEnable-Word.js > RecorderEnable-Word', () => {
       Login as Recorder and click enable again.
     */
     cy.login({
-      userName: 'TESTLANGUAGEFIVE_RECORDER_USERNAME',
-      userPassword: 'TESTLANGUAGEFIVE_RECORDER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFIVE_RECORDER',
     })
 
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFive/learn/words')
@@ -80,9 +74,7 @@ describe('RecorderEnable-Word.js > RecorderEnable-Word', () => {
       Login as Admin and verify task exists / approve task.
     */
     cy.login({
-      userName: 'TESTLANGUAGEFIVE_ADMIN_USERNAME',
-      userPassword: 'TESTLANGUAGEFIVE_ADMIN_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFIVE_ADMIN',
     })
     cy.reload()
     cy.wait(500)
@@ -96,9 +88,7 @@ describe('RecorderEnable-Word.js > RecorderEnable-Word', () => {
       Login as Site Member and check that the word is visible once enabled.
      */
     cy.login({
-      userName: 'TESTLANGUAGEFIVE_MEMBER_USERNAME',
-      userPassword: 'TESTLANGUAGEFIVE_MEMBER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFIVE_MEMBER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFive/learn/words')
     cy.wait(500)
@@ -115,9 +105,7 @@ describe('RecorderEnable-Word.js > RecorderEnable-Word', () => {
       Login as Recorder and verify that publish is now clickable.
      */
     cy.login({
-      userName: 'TESTLANGUAGEFIVE_RECORDER_USERNAME',
-      userPassword: 'TESTLANGUAGEFIVE_RECORDER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFIVE_RECORDER',
     })
 
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFive/learn/words')

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/__cypress__/RecorderMediaTrace-Word.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/__cypress__/RecorderMediaTrace-Word.js
@@ -10,9 +10,7 @@ describe('RecorderMediaTrace-Word.js > RecorderMediaTrace-Word', () => {
                 Login as Recorder and check that a test word exists and click it.
             */
     cy.login({
-      userName: 'TESTLANGUAGETWO_RECORDER_USERNAME',
-      userPassword: 'TESTLANGUAGETWO_RECORDER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGETWO_RECORDER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageTwo/learn/words')
     cy.getByTestId('DictionaryList__row').within(() => {

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/__cypress__/RecorderPublishUnpublish-Word.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/__cypress__/RecorderPublishUnpublish-Word.js
@@ -11,9 +11,7 @@ describe('RecorderPublishUnpublish-Word.js > RecorderPublishUnpublish-Word', () 
       Login as Recorder and check that the publish counter increases after it is clicked.
     */
     cy.login({
-      userName: 'TESTLANGUAGEFIVE_RECORDER_USERNAME',
-      userPassword: 'TESTLANGUAGEFIVE_RECORDER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFIVE_RECORDER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFive/learn/words')
     cy.getByTestId('DictionaryList__row').within(() => {
@@ -37,9 +35,7 @@ describe('RecorderPublishUnpublish-Word.js > RecorderPublishUnpublish-Word', () 
       Login as Admin and verify/reject task.
     */
     cy.login({
-      userName: 'TESTLANGUAGEFIVE_ADMIN_USERNAME',
-      userPassword: 'TESTLANGUAGEFIVE_ADMIN_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFIVE_ADMIN',
     })
     cy.reload()
     cy.wait(500)
@@ -54,9 +50,7 @@ describe('RecorderPublishUnpublish-Word.js > RecorderPublishUnpublish-Word', () 
       Login as recorder and click publish again.
     */
     cy.login({
-      userName: 'TESTLANGUAGEFIVE_RECORDER_USERNAME',
-      userPassword: 'TESTLANGUAGEFIVE_RECORDER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFIVE_RECORDER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFive/learn/words')
     cy.getByText('TestWord', { exact: false }).click()
@@ -73,9 +67,7 @@ describe('RecorderPublishUnpublish-Word.js > RecorderPublishUnpublish-Word', () 
       Login as Admin and verify/approve task.
     */
     cy.login({
-      userName: 'TESTLANGUAGEFIVE_ADMIN_USERNAME',
-      userPassword: 'TESTLANGUAGEFIVE_ADMIN_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFIVE_ADMIN',
     })
     cy.reload()
     cy.wait(500)
@@ -103,9 +95,7 @@ describe('RecorderPublishUnpublish-Word.js > RecorderPublishUnpublish-Word', () 
       Login as recorder and click unpublish.
     */
     cy.login({
-      userName: 'TESTLANGUAGEFIVE_RECORDER_USERNAME',
-      userPassword: 'TESTLANGUAGEFIVE_RECORDER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFIVE_RECORDER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFive/learn/words')
     cy.wait(500)
@@ -119,9 +109,7 @@ describe('RecorderPublishUnpublish-Word.js > RecorderPublishUnpublish-Word', () 
       Login as Admin and verify/reject task.
     */
     cy.login({
-      userName: 'TESTLANGUAGEFIVE_ADMIN_USERNAME',
-      userPassword: 'TESTLANGUAGEFIVE_ADMIN_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFIVE_ADMIN',
     })
     cy.reload()
     cy.wait(500)
@@ -142,9 +130,7 @@ describe('RecorderPublishUnpublish-Word.js > RecorderPublishUnpublish-Word', () 
       Login as recorder and click unpublish again.
     */
     cy.login({
-      userName: 'TESTLANGUAGEFIVE_RECORDER_USERNAME',
-      userPassword: 'TESTLANGUAGEFIVE_RECORDER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFIVE_RECORDER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFive/learn/words')
     cy.wait(500)
@@ -158,9 +144,7 @@ describe('RecorderPublishUnpublish-Word.js > RecorderPublishUnpublish-Word', () 
       Login as Admin and verify/approve task.
     */
     cy.login({
-      userName: 'TESTLANGUAGEFIVE_ADMIN_USERNAME',
-      userPassword: 'TESTLANGUAGEFIVE_ADMIN_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFIVE_ADMIN',
     })
     cy.reload()
     cy.wait(500)

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/reports/__cypress__/ReportViewFilter.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/reports/__cypress__/ReportViewFilter.js
@@ -13,9 +13,7 @@ describe('ReportViewFilter.js > ReportViewFilter', () => {
                 Login as member and navigate to the reports page.
             */
     cy.login({
-      userName: 'TESTLANGUAGEFIVE_MEMBER_USERNAME',
-      userPassword: 'TESTLANGUAGEFIVE_MEMBER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFIVE_MEMBER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFive')
     cy.get('[title="More Options"]', { exact: true }).click()
@@ -49,9 +47,7 @@ describe('ReportViewFilter.js > ReportViewFilter', () => {
                 Login as member and navigate to the reports page.
             */
     cy.login({
-      userName: 'TESTLANGUAGEFIVE_MEMBER_USERNAME',
-      userPassword: 'TESTLANGUAGEFIVE_MEMBER_PASSWORD',
-      url: 'https://dev.firstvoices.com/nuxeo/startup',
+      userName: 'TESTLANGUAGEFIVE_MEMBER',
     })
     cy.visit('/explore/FV/Workspaces/Data/TEst/Test/TestLanguageFive')
     cy.get('[title="More Options"]', { exact: true }).click()

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -53,8 +53,8 @@ afterEach(function() {
 Cypress.Commands.add('login', (obj = {}) => {
   cy.log('Confirming environment variables are set...')
   // NOTE: Cypress drops the `CYPRESS_` prefix when using environment variables set in your bash file
-  const userName = Cypress.env(obj.userName || 'ADMIN_USERNAME')
-  const userPassword = Cypress.env(obj.userPassword || 'ADMIN_PASSWORD')
+  const userName = (obj.userName || Cypress.env('ADMIN_USERNAME'))
+  const userPassword = Cypress.env(obj.userPassword || 'FV_PASSWORD' || 'ADMIN_PASSWORD')
   let loginInfoExists = false
   if (userName != undefined && userPassword != undefined) {
     loginInfoExists = true


### PR DESCRIPTION
These changes will allow Cypress to use a single password from the environment variable CYPRESS_FV_PASSWORD.  The usernames are now hardcoded, reducing the number of environment variables needed to one.