### PR TITLE
FW-727 Add Windows and Mac build test to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
       - master
 
 jobs:
-  build:
+  build_linux:
 
     runs-on: ubuntu-latest
 
@@ -24,3 +24,29 @@ jobs:
         java-version: 1.8
     - name: Build with Maven
       run: mvn clean install
+      
+  build_mac:
+
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build with Maven
+        run: mvn clean install
+
+  build_windows:
+
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build with Maven
+        run: mvn clean install


### PR DESCRIPTION
Linux, Windows, and Mac build jobs will run simultaneously on GitHub Actions.

Ensures the project build is working on all three operating systems.