### PR TITLE
FW-711-comms-updates

### DIFF
--- a/frontend/app/assets/javascripts/views/components/Navigation/Footer/Footer.css
+++ b/frontend/app/assets/javascripts/views/components/Navigation/Footer/Footer.css
@@ -1,0 +1,5 @@
+.Footer__caption {
+  font-weight: Medium;
+  font-size: 14px;
+  margin-bottom: 5px;
+}

--- a/frontend/app/assets/javascripts/views/components/Navigation/Footer/index.js
+++ b/frontend/app/assets/javascripts/views/components/Navigation/Footer/index.js
@@ -19,6 +19,8 @@ import classNames from 'classnames'
 
 import NavigationHelpers from 'common/NavigationHelpers'
 import IntlService from 'views/services/intl'
+import '!style-loader!css-loader!./Footer.css'
+
 export default class Footer extends React.Component {
   intl = IntlService.instance
 
@@ -38,13 +40,11 @@ export default class Footer extends React.Component {
           <div className="container-fluid">
             <div className="row">
               <div className={classNames('col-xs-12', 'col-md-5', 'col-md-offset-1', 'Footer__group', 'PrintHide')}>
-                <p>
-                  <small>An initiative of</small>
-                </p>
+                <p className="Footer__caption">An initiative of</p>
                 <a href="http://www.fpcc.ca/" target="_blank" rel="noopener noreferrer">
                   <img
                     src="assets/images/logo-fpcc-white.png"
-                    alt="First Peoples' Cultural Council Logo"
+                    alt="First Peoples' Cultural Council"
                     className={classNames('pull-left')}
                   />
                 </a>

--- a/frontend/app/assets/javascripts/views/components/Navigation/Footer/index.js
+++ b/frontend/app/assets/javascripts/views/components/Navigation/Footer/index.js
@@ -38,11 +38,16 @@ export default class Footer extends React.Component {
           <div className="container-fluid">
             <div className="row">
               <div className={classNames('col-xs-12', 'col-md-5', 'col-md-offset-1', 'Footer__group', 'PrintHide')}>
-                <img
-                  src="assets/images/logo-fpcc-white.png"
-                  alt="FirstVoices Logo"
-                  className={classNames('pull-left')}
-                />
+                <p>
+                  <small>An initiative of</small>
+                </p>
+                <a href="http://www.fpcc.ca/" target="_blank" rel="noopener noreferrer">
+                  <img
+                    src="assets/images/logo-fpcc-white.png"
+                    alt="First Peoples' Cultural Council Logo"
+                    className={classNames('pull-left')}
+                  />
+                </a>
               </div>
 
               <div className={classNames('col-xs-12', 'col-md-5', 'col-md-offset-1', 'Footer__group')}>

--- a/frontend/app/assets/javascripts/views/components/Navigation/index.js
+++ b/frontend/app/assets/javascripts/views/components/Navigation/index.js
@@ -200,7 +200,9 @@ export class Navigation extends Component {
           <AppLeftNav menu={{ main: true }} open={false} docked={false} />
 
           {/* Logo */}
-          <img className="Navigation__logo" src="assets/images/logo.png" alt={this.props.properties.title} />
+          <a href="/home">
+            <img className="Navigation__logo" src="assets/images/logo.png" alt={this.props.properties.title} />
+          </a>
 
           <div className="Navigation__toolbarMainInner">
             <a
@@ -639,9 +641,4 @@ const styles = (theme) => {
     localePicker,
   }
 }
-export default withStyles(styles)(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(Navigation)
-)
+export default withStyles(styles)(connect(mapStateToProps, mapDispatchToProps)(Navigation))

--- a/frontend/app/assets/javascripts/views/pages/home/index.js
+++ b/frontend/app/assets/javascripts/views/pages/home/index.js
@@ -237,7 +237,7 @@ export class PageHome extends Component {
                 <div key={i} className={classNames('col-xs-12')}>
                   <div className="body">
                     <h2 style={{ fontWeight: 500 }}>{intl.searchAndReplace(selectn('title', block))}</h2>
-                    <p dangerouslySetInnerHTML={{ __html: intl.searchAndReplace(selectn('text', block)) }} />
+                    <p dangerouslySetInnerHTML={{ __html: selectn('text', block) }} />
                   </div>
                 </div>
               )
@@ -353,9 +353,4 @@ const mapDispatchToProps = {
   queryPage,
 }
 
-export default withTheme()(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(PageHome)
-)
+export default withTheme()(connect(mapStateToProps, mapDispatchToProps)(PageHome))


### PR DESCRIPTION
- Added hrefs to FV (Header) and FPCC (Footer) logos
- bypassed intl.searchAndReplace on home page to avoid truncating text block