### PR TITLE
FW-697 kids story paging

### DIFF
--- a/frontend/app/assets/javascripts/views/hoc/grid-list/with-pagination.js
+++ b/frontend/app/assets/javascripts/views/hoc/grid-list/with-pagination.js
@@ -63,9 +63,9 @@ export default function withPagination(ComposedFilter, pageSize = 10, pageRange 
     }
 
     // TODO: Is `return false` intended?
-    shouldComponentUpdate() {
-      return false
-    }
+    // shouldComponentUpdate() {
+    //   return false
+    // }
 
     _changePage(newPageIndex) {
       this.props.fetcher(

--- a/frontend/app/assets/javascripts/views/hoc/grid-list/with-pagination.js
+++ b/frontend/app/assets/javascripts/views/hoc/grid-list/with-pagination.js
@@ -62,11 +62,6 @@ export default function withPagination(ComposedFilter, pageSize = 10, pageRange 
       this.setState({ currentPageSize: currentPageSize })
     }
 
-    // TODO: Is `return false` intended?
-    // shouldComponentUpdate() {
-    //   return false
-    // }
-
     _changePage(newPageIndex) {
       this.props.fetcher(
         Object.assign({}, this.props.fetcherParams, {


### PR DESCRIPTION
JS was receiving the content for the new pages and was passing it in as props but the component wasn't re-rendering.

Think that `shouldComponentUpdate` always returning `false` in `with-pagination.js` was preventing the Kids > Stories from updating the page content. 

Note: It's not clear to me at the moment why this issue was only present in the kids view.

> Use shouldComponentUpdate() to let React know if a component’s output is not affected by the current change in state or props.
...
This method only exists as a performance optimization. Do not rely on it to “prevent” a rendering, as this can lead to bugs.

https://reactjs.org/docs/react-component.html#shouldcomponentupdate
