### PR TITLE
FW-811 Better looking small screen view

### DIFF
--- a/frontend/app/assets/javascripts/common/UIHelpers.js
+++ b/frontend/app/assets/javascripts/common/UIHelpers.js
@@ -25,8 +25,48 @@ export default {
     dataItems.map(function dataItemsMap(entry, i) {
       rows.push(render(entry, i))
     })
-    const classNameModifier = rows.length === 1 ? 'renderComplexArrayRow--rowSingle' : ''
-    return <ol className={`renderComplexArrayRow ${classNameModifier}`}>{rows}</ol>
+
+    return (
+      <ol className={`renderComplexArrayRow ${rows.length === 1 ? 'renderComplexArrayRow--rowSingle' : ''}`}>{rows}</ol>
+    )
+  },
+  generateOrderedListFromDataset({
+    dataSet = [],
+    extractDatum = () => {},
+    classNameList = 'generateOrderedListFromDataset',
+    classNameListItem = 'generateOrderedListFromDataset__listItem',
+  }) {
+    const rows = []
+
+    dataSet.forEach((entry, i) => {
+      rows.push(
+        <li className={classNameListItem} key={i}>
+          {extractDatum(entry, i)}
+        </li>
+      )
+    })
+
+    return <ol className={`${classNameList} ${rows.length === 1 ? `${classNameList}--single` : ''}`}>{rows}</ol>
+  },
+  generateDelimitedDatumFromDataset({
+    dataSet = [],
+    extractDatum = () => {},
+    classNameContainer = '',
+    classNameText = '',
+    delimiter = ', ',
+  }) {
+    const rows = []
+
+    dataSet.forEach((entry, i) => {
+      rows.push(
+        <>
+          {i > 0 ? delimiter : ''}
+          <span className={classNameText}>{extractDatum(entry, i)}</span>
+        </>
+      )
+    })
+
+    return <span className={classNameContainer}>{rows}</span>
   },
   getPreferenceVal(key, preferences) {
     return selectn('preferences.values.' + key + '.' + selectn(key, preferences), ConfGlobal)

--- a/frontend/app/assets/javascripts/views/components/Browsing/DictionaryList.css
+++ b/frontend/app/assets/javascripts/views/components/Browsing/DictionaryList.css
@@ -1,3 +1,6 @@
+/* -------------------- */
+/* ELEMENT */
+/* -------------------- */
 .DictionaryList__colSort {
   background-color: transparent;
   border: none;
@@ -24,9 +27,6 @@
 .DictionaryList__confirmationDelete {
   margin-left: auto;
 }
-
-/* -------------------- */
-/* ELEMENT */
 .DictionaryList__data,
 .data-table td.DictionaryList__data {
   font-size: 1.6rem;
@@ -52,7 +52,12 @@
   margin: 5px;
 }
 
+.DictionaryList__definitionList {
+  padding-left: 25px;
+}
+/* -------------------- */
 /* MODIFIER */
+/* -------------------- */
 .DictionaryList--noData {
   margin: 20px 0;
 }

--- a/frontend/app/assets/javascripts/views/components/Browsing/DictionaryList.js
+++ b/frontend/app/assets/javascripts/views/components/Browsing/DictionaryList.js
@@ -262,9 +262,6 @@ const DictionaryList = (props) => {
 
   const [viewMode, setViewMode] = useState(0)
 
-  // ============= MQ
-  const [mediaQuery, setMediaQuery] = useState({})
-
   // ============= SORT
   if (props.hasSorting) {
     // If window.location.search has sortOrder & sortBy,
@@ -407,7 +404,6 @@ const DictionaryList = (props) => {
         clickHandlerViewMode: setViewMode,
         dictionaryListViewMode: props.dictionaryListViewMode,
         hasViewModeButtons: props.hasViewModeButtons,
-        mediaQueryIsSmall: mediaQuery.small,
         viewMode,
       })}
 
@@ -419,11 +415,6 @@ const DictionaryList = (props) => {
         }}
       >
         {(matches) => {
-          // =========================================
-          // save MQ data
-          // =========================================
-          setMediaQuery(matches)
-
           // =========================================
           //  All screens: no results
           // =========================================
@@ -508,41 +499,12 @@ function generateListButtons({
   clickHandlerViewMode = () => {},
   dictionaryListViewMode,
   hasViewModeButtons,
-  mediaQueryIsSmall,
   viewMode,
 }) {
-  let buttonCompact = null
   let buttonFlashcard = null
   let exportDialect = null
 
   if (hasViewModeButtons && dictionaryListViewMode === undefined) {
-    // NOTE: hiding view mode button when on small screens
-    if (mediaQueryIsSmall === false) {
-      buttonCompact =
-        viewMode === VIEWMODE_SMALL_SCREEN ? (
-          <FVButton
-            variant="contained"
-            className="DictionaryList__viewModeButton"
-            color="primary"
-            onClick={() => {
-              clickHandlerViewMode(VIEWMODE_DEFAULT)
-            }}
-          >
-            Cancel compact view
-          </FVButton>
-        ) : (
-          <FVButton
-            variant="contained"
-            className="DictionaryList__viewModeButton"
-            onClick={() => {
-              clickHandlerViewMode(VIEWMODE_SMALL_SCREEN)
-            }}
-          >
-            Compact view
-          </FVButton>
-        )
-    }
-
     buttonFlashcard =
       viewMode === VIEWMODE_FLASHCARD ? (
         <FVButton
@@ -584,7 +546,6 @@ function generateListButtons({
 
   return (
     <div className="DictionaryList__ListButtonsGroup">
-      {buttonCompact}
       {buttonFlashcard}
       {exportDialect}
     </div>

--- a/frontend/app/assets/javascripts/views/components/Browsing/DictionaryListSmallScreen.css
+++ b/frontend/app/assets/javascripts/views/components/Browsing/DictionaryListSmallScreen.css
@@ -15,10 +15,6 @@
   min-width: 225px;
   width: 100%;
 }
-.DictionaryListSmallScreen__audioGroup {
-  width: 35%;
-}
-
 .DictionaryListSmallScreen__batch {
   padding: 0 10px 0 0;
 }
@@ -101,12 +97,42 @@
 .DictionaryListSmallScreen__miscGroup {
   width: 25%;
 }
-
+.DictionaryListSmallScreen__searchType {
+  font-size: 1rem;
+  padding: 5px;
+}
 .DictionaryListSmallScreen__sortHeading {
   margin: 5px;
 }
 .DictionaryListSmallScreen__sortButton {
   margin: 5px;
+}
+
+.DictionaryListSmallScreen__item {
+  display: flex;
+}
+.DictionaryListSmallScreen__groupMain {
+  flex-grow: 1;
+}
+.DictionaryListSmallScreen__groupData {
+  padding: 0 5px 5px;
+}
+.DictionaryListSmallScreen__groupData--noHorizPad {
+  padding: 0 0 5px 0;
+}
+.DictionaryListSmallScreen__partOfSpeech {
+  font-size: 1.2rem;
+}
+.DictionaryListSmallScreen__definitionsHeading {
+  font-size: 1.4rem;
+  font-weight: 100;
+  margin: 0;
+  padding: 0 0 5px;
+}
+.DictionaryListSmallScreen__groupMainMiscellaneous {
+  font-size: 1.2rem;
+  display: flex;
+  flex-direction: row;
 }
 
 /* Modifiers

--- a/frontend/app/assets/javascripts/views/components/DialectFilterList/index.js
+++ b/frontend/app/assets/javascripts/views/components/DialectFilterList/index.js
@@ -158,7 +158,7 @@ export class DialectFilterList extends Component {
     return (
       <div className="DialectFilterList" data-testid="DialectFilterList">
         <h2>{this.title}</h2>
-        <ul className="DialectFilterListList">{this.state.listItems}</ul>
+        <ul className="DialectFilterListList DialectFilterListList--root">{this.state.listItems}</ul>
       </div>
     )
   }
@@ -452,7 +452,4 @@ const mapDispatchToProps = {
   pushWindowPath,
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(DialectFilterList)
+export default connect(mapStateToProps, mapDispatchToProps)(DialectFilterList)

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/base/data-list-view.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/base/data-list-view.js
@@ -317,7 +317,10 @@ export default class DataListView extends Component {
 
         this.state.columns.splice(stateCol, 1)
       } else {
-        this.state.columns.push({ name: 'state', title: intl.trans('state', 'State', 'first') })
+        this.state.columns.push({
+          name: 'state',
+          title: intl.trans('state', 'State', 'first'),
+        })
       }
     }
   }

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/list-view.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/list-view.js
@@ -182,10 +182,16 @@ export class PhrasesListView extends DataListView {
           columnDataTemplate: dictionaryListSmallScreenColumnDataTemplate.custom,
           columnDataTemplateCustom: dictionaryListSmallScreenColumnDataTemplateCustomInspectChildrenCellRender,
           render: (v, data, cellProps) => {
-            return UIHelpers.renderComplexArrayRow(selectn('properties.' + cellProps.name, data), (entry, i) => {
-              if (entry.language === this.props.DEFAULT_LANGUAGE && i < 2) {
-                return <li key={i}>{entry.translation}</li>
-              }
+            return UIHelpers.generateOrderedListFromDataset({
+              dataSet: selectn(`properties.${cellProps.name}`, data),
+              extractDatum: (entry, i) => {
+                if (entry.language === this.props.DEFAULT_LANGUAGE && i < 2) {
+                  return entry.translation
+                }
+                return null
+              },
+              classNameList: 'DictionaryList__definitionList',
+              classNameListItem: 'DictionaryList__definitionListItem',
             })
           },
           sortName: 'fv:definitions/0/translation',
@@ -201,7 +207,8 @@ export class PhrasesListView extends DataListView {
               return (
                 <Preview
                   minimal
-                  tagStyles={{ width: '300px', maxWidth: '100%' }}
+                  styles={{ padding: 0 }}
+                  tagStyles={{ width: '100%', minWidth: '230px' }}
                   key={selectn('uid', firstAudio)}
                   expandedValue={firstAudio}
                   type="FVAudio"
@@ -235,10 +242,10 @@ export class PhrasesListView extends DataListView {
           columnDataTemplate: dictionaryListSmallScreenColumnDataTemplate.custom,
           columnDataTemplateCustom: dictionaryListSmallScreenColumnDataTemplateCustomInspectChildren,
           render: (v, data) => {
-            return UIHelpers.renderComplexArrayRow(
-              selectn('contextParameters.phrase.phrase_books', data),
-              (entry, i) => <li key={i}>{selectn('dc:title', entry)}</li>
-            )
+            return UIHelpers.generateDelimitedDatumFromDataset({
+              dataSet: selectn('contextParameters.phrase.phrase_books', data),
+              extractDatum: (entry) => selectn('dc:title', entry),
+            })
           },
         },
         {
@@ -267,12 +274,6 @@ export class PhrasesListView extends DataListView {
         page: this.props.DEFAULT_PAGE,
         pageSize: this.props.DEFAULT_PAGE_SIZE,
       },
-    }
-
-    // Reduce the number of columns displayed for mobile
-    if (UIHelpers.isViewSize('xs')) {
-      this.state.columns = this.state.columns.filter((v) => ['title', 'fv:definitions'].indexOf(v.name) !== -1)
-      this.state.hideStateColumn = true
     }
 
     // Only show enabled cols if specified
@@ -378,38 +379,32 @@ export class PhrasesListView extends DataListView {
             type={'FVPhrase'}
             dictionaryListSmallScreenTemplate={({ templateData }) => {
               return (
-                <div className="DictionaryListSmallScreen__words">
-                  <div className="DictionaryListSmallScreen__groupPrimary">
-                    {templateData.related_pictures}
-                    {templateData.title}
-                  </div>
-
-                  <div className="DictionaryListSmallScreen__groupSecondary">
-                    {templateData['fv:definitions']}
-                    <div className="DictionaryListSmallScreen__groupSecondary">
+                <div className="DictionaryListSmallScreen__item">
+                  <div className="DictionaryListSmallScreen__groupMain">
+                    <div className="DictionaryListSmallScreen__groupData DictionaryListSmallScreen__groupData--noHorizPad">
+                      {templateData.title}
+                      <span className="DictionaryListSmallScreen__partOfSpeech">
+                        {templateData['fv-word:part_of_speech']}
+                      </span>
+                    </div>
+                    <div className="DictionaryListSmallScreen__groupData DictionaryListSmallScreen__groupData--noHorizPad">
                       {templateData.related_audio}
-                      {templateData['dc:description']}
+                    </div>
 
-                      {templateData['fv-word:part_of_speech']}
+                    <div className="DictionaryListSmallScreen__groupData">
+                      <h2 className="DictionaryListSmallScreen__definitionsHeading">Definitions</h2>
+                      {templateData['fv:definitions']}
+                    </div>
 
-                      {templateData['thumb:thumbnail']}
-
-                      {templateData['fv-word:categories']}
-                      {templateData.parent}
-                      {templateData['fv-phrase:phrase_books']}
-
-                      {templateData.username}
-
-                      {templateData.email}
-
-                      {templateData['fvlink:url']}
-
-                      {templateData['dc:modified']}
-                      {templateData['dc:created']}
-                      {templateData.state}
-                      {templateData.actions}
+                    <div className="DictionaryListSmallScreen__groupMainMiscellaneous">
+                      <div className="DictionaryListSmallScreen__groupData">
+                        {templateData['fv-phrase:phrase_books']}
+                      </div>
+                      <div className="DictionaryListSmallScreen__groupData">{templateData.state}</div>
                     </div>
                   </div>
+
+                  <div className="DictionaryListSmallScreen__groupData">{templateData.related_pictures}</div>
                 </div>
               )
             }}

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/list-view.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/list-view.js
@@ -196,10 +196,16 @@ class WordsListView extends DataListView {
           columnDataTemplate: dictionaryListSmallScreenColumnDataTemplate.custom,
           columnDataTemplateCustom: dictionaryListSmallScreenColumnDataTemplateCustomInspectChildrenCellRender,
           render: (v, data, cellProps) => {
-            return UIHelpers.renderComplexArrayRow(selectn(`properties.${cellProps.name}`, data), (entry, i) => {
-              if (entry.language === this.props.DEFAULT_LANGUAGE && i < 2) {
-                return <li key={i}>{entry.translation}</li>
-              }
+            return UIHelpers.generateOrderedListFromDataset({
+              dataSet: selectn(`properties.${cellProps.name}`, data),
+              extractDatum: (entry, i) => {
+                if (entry.language === this.props.DEFAULT_LANGUAGE && i < 2) {
+                  return entry.translation
+                }
+                return null
+              },
+              classNameList: 'DictionaryList__definitionList',
+              classNameListItem: 'DictionaryList__definitionListItem',
             })
           },
           sortName: 'fv:definitions/0/translation',
@@ -217,7 +223,8 @@ class WordsListView extends DataListView {
                   key={selectn('uid', firstAudio)}
                   minimal
                   tagProps={{ preload: 'none' }}
-                  tagStyles={{ width: '250px', maxWidth: '100%' }}
+                  styles={{ padding: 0 }}
+                  tagStyles={{ width: '100%', minWidth: '230px' }}
                   expandedValue={firstAudio}
                   type="FVAudio"
                 />
@@ -248,6 +255,7 @@ class WordsListView extends DataListView {
         {
           name: 'fv-word:part_of_speech',
           title: intl.trans('part_of_speech', 'Part of Speech', 'first'),
+          columnDataTemplate: dictionaryListSmallScreenColumnDataTemplate.cellRender,
           render: (v, data) => selectn('contextParameters.word.part_of_speech', data),
           sortBy: 'fv-word:part_of_speech',
         },
@@ -270,10 +278,12 @@ class WordsListView extends DataListView {
         {
           name: 'fv-word:categories',
           title: intl.trans('categories', 'Categories', 'first'),
-          render: (v, data) =>
-            UIHelpers.renderComplexArrayRow(selectn('contextParameters.word.categories', data), (entry, i) => (
-              <li key={i}>{selectn('dc:title', entry)}</li>
-            )),
+          render: (v, data) => {
+            return UIHelpers.generateDelimitedDatumFromDataset({
+              dataSet: selectn('contextParameters.word.categories', data),
+              extractDatum: (entry) => selectn('dc:title', entry),
+            })
+          },
         },
       ],
       sortInfo: {
@@ -285,12 +295,6 @@ class WordsListView extends DataListView {
         page: this.props.DEFAULT_PAGE,
         pageSize: this.props.DEFAULT_PAGE_SIZE,
       },
-    }
-
-    // Reduce the number of columns displayed for mobile
-    if (UIHelpers.isViewSize('xs')) {
-      this.state.columns = this.state.columns.filter((v) => ['title', 'fv:literal_translation'].indexOf(v.name) !== -1)
-      this.state.hideStateColumn = true
     }
 
     // Only show enabled cols if specified
@@ -458,38 +462,30 @@ class WordsListView extends DataListView {
             type={'FVWord'}
             dictionaryListSmallScreenTemplate={({ templateData }) => {
               return (
-                <div className="DictionaryListSmallScreen__words">
-                  <div className="DictionaryListSmallScreen__groupPrimary">
-                    {templateData.related_pictures}
-                    {templateData.title}
-                  </div>
-
-                  <div className="DictionaryListSmallScreen__groupSecondary">
-                    {templateData['fv:definitions']}
-                    <div className="DictionaryListSmallScreen__groupSecondary">
+                <div className="DictionaryListSmallScreen__item">
+                  <div className="DictionaryListSmallScreen__groupMain">
+                    <div className="DictionaryListSmallScreen__groupData DictionaryListSmallScreen__groupData--noHorizPad">
+                      {templateData.title}
+                      <span className="DictionaryListSmallScreen__partOfSpeech">
+                        {templateData['fv-word:part_of_speech']}
+                      </span>
+                    </div>
+                    <div className="DictionaryListSmallScreen__groupData DictionaryListSmallScreen__groupData--noHorizPad">
                       {templateData.related_audio}
-                      {templateData['dc:description']}
+                    </div>
 
-                      {templateData['fv-word:part_of_speech']}
+                    <div className="DictionaryListSmallScreen__groupData">
+                      <h2 className="DictionaryListSmallScreen__definitionsHeading">Definitions</h2>
+                      {templateData['fv:definitions']}
+                    </div>
 
-                      {templateData['thumb:thumbnail']}
-
-                      {templateData['fv-word:categories']}
-                      {templateData.parent}
-                      {templateData['fv-phrase:phrase_books']}
-
-                      {templateData.username}
-
-                      {templateData.email}
-
-                      {templateData['fvlink:url']}
-
-                      {templateData['dc:modified']}
-                      {templateData['dc:created']}
-                      {templateData.state}
-                      {templateData.actions}
+                    <div className="DictionaryListSmallScreen__groupMainMiscellaneous">
+                      <div className="DictionaryListSmallScreen__groupData">{templateData['fv-word:categories']}</div>
+                      <div className="DictionaryListSmallScreen__groupData">{templateData.state}</div>
                     </div>
                   </div>
+
+                  <div className="DictionaryListSmallScreen__groupData">{templateData.related_pictures}</div>
                 </div>
               )
             }}

--- a/frontend/app/assets/javascripts/views/pages/search/index.js
+++ b/frontend/app/assets/javascripts/views/pages/search/index.js
@@ -435,30 +435,26 @@ export class Search extends DataListView {
                             {
                               name: 'type',
                               title: 'Type',
-                              columnDataTemplate: dictionaryListSmallScreenColumnDataTemplate.cellRenderTypography,
-                              typographyVariant: 'subheading',
+                              columnDataTemplate: dictionaryListSmallScreenColumnDataTemplate.cellRender,
                               render: (v, data) => {
+                                const family = selectn(['contextParameters', 'ancestry', 'family', 'dc:title'], data)
+                                const language = selectn(
+                                  ['contextParameters', 'ancestry', 'language', 'dc:title'],
+                                  data
+                                )
                                 let itemType
                                 switch (data.type) {
                                   case 'FVPhrase':
-                                    itemType = 'Phrase'
+                                    itemType = `${language} » Phrase`
                                     break
                                   case 'FVWord':
-                                    itemType = 'Word'
+                                    itemType = `${language} » Word`
                                     break
                                   case 'FVBook':
-                                    itemType = data.properties['fvbook:type']
+                                    itemType = `${language} » ${data.properties['fvbook:type']}`
                                     break
                                   case 'FVPortal': {
-                                    const family = selectn(
-                                      ['contextParameters', 'ancestry', 'family', 'dc:title'],
-                                      data
-                                    )
-                                    const language = selectn(
-                                      ['contextParameters', 'ancestry', 'language', 'dc:title'],
-                                      data
-                                    )
-                                    itemType = `Dialect: ${family} » ${language}`
+                                    itemType = `${family} » ${language}`
                                     break
                                   }
                                   default:
@@ -583,14 +579,17 @@ export class Search extends DataListView {
                               columnDataTemplate: dictionaryListSmallScreenColumnDataTemplate.custom,
                               columnDataTemplateCustom: dictionaryListSmallScreenColumnDataTemplateCustomInspectChildrenCellRender,
                               render: (v, data, cellProps) => {
-                                return UIHelpers.renderComplexArrayRow(
-                                  selectn('properties.' + cellProps.name, data),
-                                  (entry, i) => {
+                                return UIHelpers.generateOrderedListFromDataset({
+                                  dataSet: selectn(`properties.${cellProps.name}`, data),
+                                  extractDatum: (entry, i) => {
                                     if (entry.language === this.props.DEFAULT_LANGUAGE && i < 2) {
-                                      return <div key={i}>{entry.translation}</div>
+                                      return entry.translation
                                     }
-                                  }
-                                )
+                                    return null
+                                  },
+                                  classNameList: 'DictionaryList__definitionList',
+                                  classNameListItem: 'DictionaryList__definitionListItem',
+                                })
                               },
                               sortName: 'fv:definitions/0/translation',
                             },
@@ -612,8 +611,8 @@ export class Search extends DataListView {
                                   return (
                                     <Preview
                                       minimal
-                                      tagStyles={{ width: '300px', maxWidth: '100%' }}
-                                      styles={{ padding: '0' }}
+                                      styles={{ padding: 0 }}
+                                      tagStyles={{ width: '100%', minWidth: '230px' }}
                                       key={selectn('uid', firstAudio)}
                                       expandedValue={firstAudio}
                                       type="FVAudio"
@@ -625,14 +624,27 @@ export class Search extends DataListView {
                           ],
                           dictionaryListSmallScreenTemplate: ({ templateData }) => {
                             return (
-                              <>
-                                {templateData.type}
-                                {templateData.title}
-                                <div className="DictionaryListSmallScreen__group">
-                                  {templateData['fv:definitions']}
-                                  {templateData.related_audio}
+                              <div className="DictionaryListSmallScreen__item">
+                                <div className="DictionaryListSmallScreen__groupMain">
+                                  <div className="DictionaryListSmallScreen__groupMainMiscellaneous">
+                                    <div className="DictionaryListSmallScreen__searchType">{templateData.type}</div>
+                                  </div>
+                                  <div className="DictionaryListSmallScreen__groupData DictionaryListSmallScreen__groupData--noHorizPad">
+                                    {templateData.title}
+                                  </div>
+                                  {templateData.related_audio && (
+                                    <div className="DictionaryListSmallScreen__groupData DictionaryListSmallScreen__groupData--noHorizPad">
+                                      {templateData.related_audio}
+                                    </div>
+                                  )}
+                                  {templateData['fv:definitions'] && (
+                                    <div className="DictionaryListSmallScreen__groupData">
+                                      <h2 className="DictionaryListSmallScreen__definitionsHeading">Definitions</h2>
+                                      {templateData['fv:definitions']}
+                                    </div>
+                                  )}
                                 </div>
-                              </>
+                              </div>
                             )
                           },
                         },

--- a/frontend/app/assets/stylesheets/AlphabetListView.less
+++ b/frontend/app/assets/stylesheets/AlphabetListView.less
@@ -35,3 +35,11 @@ a.AlphabetListViewTile {
   color: #820000;
   border-color: #820000;
 }
+
+@media (max-width: @medium-screen) {
+  .AlphabetListViewTiles {
+    max-height: 120px;
+    overflow: auto;
+    box-shadow: 0px 2px 6px 0px rgba(0, 0, 0, 0.12);
+  }
+}

--- a/frontend/app/assets/stylesheets/DialectFilterList.less
+++ b/frontend/app/assets/stylesheets/DialectFilterList.less
@@ -57,3 +57,14 @@ a.DialectFilterListLink--activeParent:hover {
 .DialectFilterListItemParent--active {
   border-left: 3px solid #820000;
 }
+
+@media (max-width: @medium-screen) {
+  .DialectFilterListLink {
+    padding: 5px;
+  }
+  .DialectFilterListList--root {
+    max-height: 120px;
+    overflow: auto;
+    box-shadow: 0px 2px 6px 0px rgba(0, 0, 0, 0.12);
+  }
+}

--- a/frontend/app/assets/stylesheets/SearchDialect.less
+++ b/frontend/app/assets/stylesheets/SearchDialect.less
@@ -48,3 +48,11 @@
   width: 100%;
   justify-content: space-between
 }
+@media (max-width: @small-screen) {
+  .SearchDialectFormPrimary {
+    flex-wrap: wrap;
+  }
+  .SearchDialectFormSecondaryGroup {
+    padding: 0 0 5px;
+  }
+}

--- a/frontend/app/assets/stylesheets/main.less
+++ b/frontend/app/assets/stylesheets/main.less
@@ -32,6 +32,7 @@ body {
 @primary-header-color: #666666;
 @mobile-xs-width: 480px;
 @small-screen: 650px;
+@medium-screen: 991px;
 @font-family: Arial, sans-serif;
 @font-family-aboriginal-sans: "Aboriginal Sans", "Aboriginal Serif", "Lucida Grande", "Lucida Sans Unicode", Gentium,
   Code2001;


### PR DESCRIPTION
Removed the 'Compact view' button since more rows can fit in the desktop view. The new 'compact' view is meant to improve design on small screens and not fit in as many entries as possible.

Impacts:
- Phrases & words: small view
- Search: all views