### PR TITLE
FW-740

### DIFF
--- a/frontend/app/assets/javascripts/providers/redux/reducers/listView/reducer.js
+++ b/frontend/app/assets/javascripts/providers/redux/reducers/listView/reducer.js
@@ -2,12 +2,6 @@ import { LISTVIEW_UPDATE } from './actionTypes'
 
 const initialState = {
   mode: 0,
-  decoder: {
-    default: 0,
-    flashcard: 1,
-    compact: 2,
-    print: 3,
-  },
 }
 
 export const listViewReducer = (state = initialState, action) => {

--- a/frontend/app/assets/javascripts/views/components/Browsing/DictionaryList.js
+++ b/frontend/app/assets/javascripts/views/components/Browsing/DictionaryList.js
@@ -260,8 +260,6 @@ const DictionaryList = (props) => {
   const DefaultFetcherParams = { currentPageIndex: 1, pageSize: 10, sortBy: 'fv:custom_order', sortOrder: 'asc' }
   let columnsEnhanced = [...props.columns]
 
-  const [viewMode, setViewMode] = useState(0)
-
   // ============= SORT
   if (props.hasSorting) {
     // If window.location.search has sortOrder & sortBy,
@@ -401,10 +399,9 @@ const DictionaryList = (props) => {
         exportDialectQuery: props.exportDialectQuery,
         hasExportDialect: props.hasExportDialect,
         // View mode
-        clickHandlerViewMode: setViewMode,
+        clickHandlerViewMode: props.dictionaryListClickHandlerViewMode,
         dictionaryListViewMode: props.dictionaryListViewMode,
         hasViewModeButtons: props.hasViewModeButtons,
-        viewMode,
       })}
 
       <Media
@@ -428,7 +425,7 @@ const DictionaryList = (props) => {
 
           //  Flashcard Specified: by view mode button or prop
           // -----------------------------------------
-          if (viewMode === VIEWMODE_FLASHCARD || props.dictionaryListViewMode === VIEWMODE_FLASHCARD) {
+          if (props.dictionaryListViewMode === VIEWMODE_FLASHCARD) {
             // TODO: SPECIFY FlashcardList PROPS
             let flashCards = <FlashcardList {...props} />
             if (props.hasPagination) {
@@ -440,7 +437,7 @@ const DictionaryList = (props) => {
 
           //  Small Screen Specified: by view mode button or prop
           // -----------------------------------------
-          if (viewMode === VIEWMODE_SMALL_SCREEN || props.dictionaryListViewMode === VIEWMODE_SMALL_SCREEN) {
+          if (props.dictionaryListViewMode === VIEWMODE_SMALL_SCREEN) {
             return getListSmallScreen(getListSmallScreenArg)
           }
 
@@ -499,14 +496,13 @@ function generateListButtons({
   clickHandlerViewMode = () => {},
   dictionaryListViewMode,
   hasViewModeButtons,
-  viewMode,
 }) {
   let buttonFlashcard = null
   let exportDialect = null
 
-  if (hasViewModeButtons && dictionaryListViewMode === undefined) {
+  if (hasViewModeButtons) {
     buttonFlashcard =
-      viewMode === VIEWMODE_FLASHCARD ? (
+      dictionaryListViewMode === VIEWMODE_FLASHCARD ? (
         <FVButton
           variant="contained"
           color="primary"
@@ -756,6 +752,7 @@ DictionaryList.propTypes = {
   cssModifier: string,
   dialect: object,
   dictionaryListSmallScreenTemplate: func,
+  dictionaryListClickHandlerViewMode: func,
   dictionaryListViewMode: number,
   fields: instanceOf(Map),
   filteredItems: oneOfType([array, instanceOf(List)]),
@@ -796,6 +793,7 @@ DictionaryList.defaultProps = {
   cols: 3,
   columns: [],
   cssModifier: '',
+  dictionaryListClickHandlerViewMode: () => {},
   // sortHandler: () => {},
   style: null,
   wrapperStyle: null,
@@ -808,7 +806,6 @@ DictionaryList.defaultProps = {
   resetSearch: () => {},
   // REDUX: actions/dispatch/func
   pushWindowPath: () => {},
-  setListViewMode: () => {},
 }
 
 // REDUX: reducers/state

--- a/frontend/app/assets/javascripts/views/components/Document/DocumentListView/index.js
+++ b/frontend/app/assets/javascripts/views/components/Document/DocumentListView/index.js
@@ -75,6 +75,8 @@ const DocumentListView = (props) => {
           hasSearch={props.hasSearch}
           hasViewModeButtons={props.hasViewModeButtons}
           rowClickHandler={props.rowClickHandler}
+          dictionaryListClickHandlerViewMode={props.dictionaryListClickHandlerViewMode}
+          dictionaryListViewMode={props.dictionaryListViewMode}
           dictionaryListSmallScreenTemplate={props.dictionaryListSmallScreenTemplate}
           // Listview: Batch
           batchConfirmationAction={props.batchConfirmationAction}

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/index.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/index.js
@@ -27,6 +27,7 @@ import { fetchPortal } from 'providers/redux/reducers/fvPortal'
 import { overrideBreadcrumbs, updatePageProperties } from 'providers/redux/reducers/navigation'
 import { pushWindowPath } from 'providers/redux/reducers/windowPath'
 import { searchDialectUpdate } from 'providers/redux/reducers/searchDialect'
+import { setListViewMode } from 'providers/redux/reducers/listView'
 
 import selectn from 'selectn'
 
@@ -193,6 +194,8 @@ export class PageDialectLearnPhrases extends PageDialectLearnBase {
         searchByMode={searchByMode}
         rowClickHandler={this.props.rowClickHandler}
         hasSorting={this.props.hasSorting}
+        dictionaryListClickHandlerViewMode={this.props.setListViewMode}
+        dictionaryListViewMode={this.props.listView.mode}
       />
     ) : (
       <div />
@@ -458,7 +461,7 @@ export class PageDialectLearnPhrases extends PageDialectLearnBase {
 
 // REDUX: reducers/state
 const mapStateToProps = (state /*, ownProps*/) => {
-  const { document, fvCategory, fvPortal, navigation, nuxeo, searchDialect, windowPath } = state
+  const { document, fvCategory, fvPortal, listView, navigation, nuxeo, searchDialect, windowPath } = state
 
   const { computeCategories } = fvCategory
   const { computeDocument } = document
@@ -474,6 +477,7 @@ const mapStateToProps = (state /*, ownProps*/) => {
     computeLogin,
     computePortal,
     computeSearchDialect,
+    listView,
     properties,
     splitWindowPath,
     windowPath: _windowPath,
@@ -488,6 +492,7 @@ const mapDispatchToProps = {
   overrideBreadcrumbs,
   pushWindowPath,
   searchDialectUpdate,
+  setListViewMode,
   updatePageProperties,
 }
 

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/list-view.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/list-view.js
@@ -377,6 +377,8 @@ export class PhrasesListView extends DataListView {
               })
             }}
             type={'FVPhrase'}
+            dictionaryListClickHandlerViewMode={this.props.dictionaryListClickHandlerViewMode}
+            dictionaryListViewMode={this.props.dictionaryListViewMode}
             dictionaryListSmallScreenTemplate={({ templateData }) => {
               return (
                 <div className="DictionaryListSmallScreen__item">

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/index.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/index.js
@@ -27,6 +27,7 @@ import { fetchPortal } from 'providers/redux/reducers/fvPortal'
 import { overrideBreadcrumbs, updatePageProperties } from 'providers/redux/reducers/navigation'
 import { pushWindowPath, replaceWindowPath } from 'providers/redux/reducers/windowPath'
 import { searchDialectUpdate } from 'providers/redux/reducers/searchDialect'
+import { setListViewMode } from 'providers/redux/reducers/listView'
 
 import selectn from 'selectn'
 
@@ -203,6 +204,8 @@ class PageDialectLearnWords extends PageDialectLearnBase {
             // ],
           },
         ]}
+        dictionaryListClickHandlerViewMode={this.props.setListViewMode}
+        dictionaryListViewMode={this.props.listView.mode}
       />
     ) : null
 
@@ -478,7 +481,7 @@ class PageDialectLearnWords extends PageDialectLearnBase {
 
 // REDUX: reducers/state
 const mapStateToProps = (state /*, ownProps*/) => {
-  const { document, fvCategory, fvPortal, navigation, nuxeo, searchDialect, windowPath } = state
+  const { document, fvCategory, fvPortal, listView, navigation, nuxeo, searchDialect, windowPath } = state
 
   const { computeCategories } = fvCategory
   const { computeDocument } = document
@@ -493,6 +496,7 @@ const mapStateToProps = (state /*, ownProps*/) => {
     computeLogin,
     computePortal,
     computeSearchDialect,
+    listView,
     properties,
     splitWindowPath,
     windowPath: _windowPath,
@@ -508,6 +512,7 @@ const mapDispatchToProps = {
   pushWindowPath,
   replaceWindowPath,
   searchDialectUpdate,
+  setListViewMode,
   updatePageProperties,
 }
 

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/list-view.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/list-view.js
@@ -460,6 +460,8 @@ class WordsListView extends DataListView {
               })
             }}
             type={'FVWord'}
+            dictionaryListClickHandlerViewMode={this.props.dictionaryListClickHandlerViewMode}
+            dictionaryListViewMode={this.props.dictionaryListViewMode}
             dictionaryListSmallScreenTemplate={({ templateData }) => {
               return (
                 <div className="DictionaryListSmallScreen__item">
@@ -530,8 +532,8 @@ const mapStateToProps = (state /*, ownProps*/) => {
 
 // REDUX: actions/dispatch/func
 const mapDispatchToProps = {
-  fetchWords,
   fetchDialect2,
+  fetchWords,
   pushWindowPath,
   setRouteParams,
 }


### PR DESCRIPTION
Reinstated redux controlled view mode settings

Moved the view mode code up a few ancestors to dialect/learn/phrases
and dialect/learn/words.

This location allows persistant view mode settings on Words & Phrases
but is not applied to forms (via Browse > list-view)