### PR TITLE
FW-871

### DIFF
--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/header.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/header.js
@@ -30,13 +30,13 @@ export default class Header extends Component {
     portal: PropTypes.object,
     dialect: PropTypes.object,
     login: PropTypes.object,
-    shouldShowStats: PropTypes.bool,
+    isStatisticsVisible: PropTypes.bool,
     handleShowStats: PropTypes.func,
     routeParams: PropTypes.object,
   }
 
   static defaultProps = {
-    shouldShowStats: false,
+    isStatisticsVisible: false,
     handleShowStats: () => {},
   }
 
@@ -49,7 +49,7 @@ export default class Header extends Component {
   }
 
   render() {
-    const { portal, login, routeParams, shouldShowStats } = this.props
+    const { portal, login, routeParams, isStatisticsVisible } = this.props
 
     const backgroundImage = selectn(
       'response.contextParameters.portal.fv-portal:background_top_image.path',
@@ -77,7 +77,7 @@ export default class Header extends Component {
     return (
       <div className="Header row" style={portalBackgroundStyles}>
         <AuthenticationFilter login={login} hideFromSections routeParams={routeParams}>
-          {shouldShowStats && (
+          {isStatisticsVisible && (
             <PageStats handleShowStats={this.props.handleShowStats} dialectPath={routeParams.dialect_path} />
           )}
         </AuthenticationFilter>

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/alphabet/index.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/alphabet/index.js
@@ -233,7 +233,7 @@ export class PageDialectLearnAlphabet extends PageDialectLearnBase {
           login={this.props.computeLogin}
           routeParams={this.props.routeParams}
         >
-          <ToolbarNavigation showStats={this._showStats} routeParams={this.props.routeParams} />
+          <ToolbarNavigation hideStatistics routeParams={this.props.routeParams} />
         </Header>
 
         <div className={classNames('row', 'dialect-body-container')} style={{ marginTop: '15px' }}>

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/base/toolbar-navigation.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/base/toolbar-navigation.js
@@ -39,11 +39,13 @@ const intl = IntlService.instance
  * Navigation for learning page
  */
 
-const { array, func, object, string } = PropTypes
+const { array, bool, func, object, string } = PropTypes
 export class ToolbarNavigation extends Component {
   static propTypes = {
     routeParams: object.isRequired,
-    showStats: func,
+    handleShowStats: func,
+    hideStatistics: bool,
+    isStatisticsVisible: bool,
     // REDUX: reducers/state
     computeLogin: object.isRequired,
     computeResultSet: object.isRequired,
@@ -145,7 +147,7 @@ export class ToolbarNavigation extends Component {
               </a>
             </div>
           </div>
-          {this.props.shouldShowStats !== true && (
+          {this.props.hideStatistics !== true && this.props.isStatisticsVisible !== true && (
             <AuthenticationFilter login={this.props.computeLogin} hideFromSections routeParams={this.props.routeParams}>
               <div className="col-xs-12 col-md-2">
                 <div className={classNames('hidden-xs')} float="right">

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/index.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/index.js
@@ -395,13 +395,13 @@ export class DialectLearn extends Component {
           portal={{ compute: computePortal, update: this.props.updatePortal }}
           dialect={{ compute: computeDialect2, update: this.props.updateDialect2 }}
           login={computeLogin}
-          shouldShowStats={this.state.showStats}
+          isStatisticsVisible={this.state.showStats}
           handleShowStats={this._showStats}
           routeParams={this.props.routeParams}
         >
           <ToolbarNavigation
             routeParams={this.props.routeParams}
-            shouldShowStats={this.state.showStats}
+            isStatisticsVisible={this.state.showStats}
             handleShowStats={this._showStats}
           />
         </Header>


### PR DESCRIPTION
- Added `hideStatistics` prop to ToolbarNavigation to disable the button
- Renamed var for clarity: `shouldShowStats` to `isStatisticsVisible`

---
Note: `hideStatistics` should probably be a temporary solution (so as not to delay the release).

**Possible future changes**

A better solution could be passing the button in to `toolbar-navigation` via it’s `props.children` which would eliminate the need for `hideStatistics`

Alternatively…

The button and modal for Statistics are spread between two components: `toolbar-navigation` and `header`. It might be a better idea to group the parts inside of a single component.