### PR TITLE
Add optional -skip-tests flag to UpdateModule scripts

### DIFF
--- a/FVUserRegistration/UpdateModule.sh
+++ b/FVUserRegistration/UpdateModule.sh
@@ -8,4 +8,8 @@ MODULE=${DIRECTORY##*/}
 
 # Run the main UpdateModule script in the docker directory
 cd $DIRECTORY
-../docker/UpdateModuleMain.sh $MODULE
+if [[ "$1" == "-skip-tests" ]]; then
+    ../docker/UpdateModuleMain.sh $MODULE $1
+else
+    ../docker/UpdateModuleMain.sh $MODULE
+fi

--- a/FirstVoices-marketplace/UpdateModule.sh
+++ b/FirstVoices-marketplace/UpdateModule.sh
@@ -8,4 +8,8 @@ MODULE=${DIRECTORY##*/}
 
 # Run the main UpdateModule script in the docker directory
 cd $DIRECTORY
-../docker/UpdateModuleMain.sh $MODULE
+if [[ "$1" == "-skip-tests" ]]; then
+    ../docker/UpdateModuleMain.sh $MODULE $1
+else
+    ../docker/UpdateModuleMain.sh $MODULE
+fi

--- a/FirstVoicesData/UpdateModule.sh
+++ b/FirstVoicesData/UpdateModule.sh
@@ -8,4 +8,8 @@ MODULE=${DIRECTORY##*/}
 
 # Run the main UpdateModule script in the docker directory
 cd $DIRECTORY
-../docker/UpdateModuleMain.sh $MODULE
+if [[ "$1" == "-skip-tests" ]]; then
+    ../docker/UpdateModuleMain.sh $MODULE $1
+else
+    ../docker/UpdateModuleMain.sh $MODULE
+fi

--- a/FirstVoicesDraftEditor/UpdateModule.sh
+++ b/FirstVoicesDraftEditor/UpdateModule.sh
@@ -8,4 +8,8 @@ MODULE=${DIRECTORY##*/}
 
 # Run the main UpdateModule script in the docker directory
 cd $DIRECTORY
-../docker/UpdateModuleMain.sh $MODULE
+if [[ "$1" == "-skip-tests" ]]; then
+    ../docker/UpdateModuleMain.sh $MODULE $1
+else
+    ../docker/UpdateModuleMain.sh $MODULE
+fi

--- a/FirstVoicesEnrichers/UpdateModule.sh
+++ b/FirstVoicesEnrichers/UpdateModule.sh
@@ -8,4 +8,8 @@ MODULE=${DIRECTORY##*/}
 
 # Run the main UpdateModule script in the docker directory
 cd $DIRECTORY
-../docker/UpdateModuleMain.sh $MODULE
+if [[ "$1" == "-skip-tests" ]]; then
+    ../docker/UpdateModuleMain.sh $MODULE $1
+else
+    ../docker/UpdateModuleMain.sh $MODULE
+fi

--- a/FirstVoicesExport/UpdateModule.sh
+++ b/FirstVoicesExport/UpdateModule.sh
@@ -8,4 +8,8 @@ MODULE=${DIRECTORY##*/}
 
 # Run the main UpdateModule script in the docker directory
 cd $DIRECTORY
-../docker/UpdateModuleMain.sh $MODULE
+if [[ "$1" == "-skip-tests" ]]; then
+    ../docker/UpdateModuleMain.sh $MODULE $1
+else
+    ../docker/UpdateModuleMain.sh $MODULE
+fi

--- a/FirstVoicesPublisher/UpdateModule.sh
+++ b/FirstVoicesPublisher/UpdateModule.sh
@@ -8,4 +8,8 @@ MODULE=${DIRECTORY##*/}
 
 # Run the main UpdateModule script in the docker directory
 cd $DIRECTORY
-../docker/UpdateModuleMain.sh $MODULE
+if [[ "$1" == "-skip-tests" ]]; then
+    ../docker/UpdateModuleMain.sh $MODULE $1
+else
+    ../docker/UpdateModuleMain.sh $MODULE
+fi

--- a/FirstVoicesSecurity/UpdateModule.sh
+++ b/FirstVoicesSecurity/UpdateModule.sh
@@ -8,4 +8,8 @@ MODULE=${DIRECTORY##*/}
 
 # Run the main UpdateModule script in the docker directory
 cd $DIRECTORY
-../docker/UpdateModuleMain.sh $MODULE
+if [[ "$1" == "-skip-tests" ]]; then
+    ../docker/UpdateModuleMain.sh $MODULE $1
+else
+    ../docker/UpdateModuleMain.sh $MODULE
+fi

--- a/docker/README.md
+++ b/docker/README.md
@@ -113,6 +113,8 @@ docker exec nuxeo-dev /bin/bash -c "nuxeoctl stop && nuxeoctl mp-install --accep
 * From the root of your module run the command ```./UpdateModule.sh```. If you are creating a new module you will need to copy the UpdateModule.sh script from another module into the root of your module
 (eg: copy ```/FirstVoicesData/UpdateModule.sh``` into ```/YourNewModule```).
 
+    Optionally you can add the flag ```-skip-tests``` to skip the compilation and running of unit tests during the module deploy (eg: ```./UpdateModule.sh -skip-tests```).
+
 * Alternatively navigate to ```docker/``` and run the command ```./UpdateModuleMain.sh <ModuleName>``` where ```<ModuleName>``` is the name of the module you have created/made changes to (eg: ```./UpdateModuleMain.sh FirstVoicesData```).
   
   Both of the above will build the module, remove any old copies inside of the docker container, copy the new jarfile into the docker container, and restart the nuxeo backend to deploy the changes/module.

--- a/docker/UpdateModuleMain.sh
+++ b/docker/UpdateModuleMain.sh
@@ -18,13 +18,23 @@ fi
 
 # Build main module.
 echo 'Building module: ' $MODULE
-mvn clean install
-if [[ "$?" -ne 0 ]]; then
-    echo
-    echo -e "${RED}fv-web-ui build failed \n${ENDCOLOR}"; exit 1
-    echo
+if [ "$2" == "-skip-tests" ]; then
+    mvn -Dmaven.test.skip=true install
+    if [[ "$?" -ne 0 ]]; then
+        echo
+        echo -e "${RED}fv-web-ui build failed \n${ENDCOLOR}"; exit 1
+        echo
+    fi
+    echo ''
+else
+    mvn clean install
+    if [[ "$?" -ne 0 ]]; then
+        echo
+        echo -e "${RED}fv-web-ui build failed \n${ENDCOLOR}"; exit 1
+        echo
+    fi
+    echo ''
 fi
-echo ''
 
 # Remove any old modules from the docker container if they exists
 echo 'Removing old module from docker container if it exists.'

--- a/migration-contributions/UpdateModule.sh
+++ b/migration-contributions/UpdateModule.sh
@@ -8,4 +8,8 @@ MODULE=${DIRECTORY##*/}
 
 # Run the main UpdateModule script in the docker directory
 cd $DIRECTORY
-../docker/UpdateModuleMain.sh $MODULE
+if [[ "$1" == "-skip-tests" ]]; then
+    ../docker/UpdateModuleMain.sh $MODULE $1
+else
+    ../docker/UpdateModuleMain.sh $MODULE
+fi


### PR DESCRIPTION
Running the update module script with the -skip-tests flag will skip compilation and running of unit tests during a local module docker deploy. 
To run: ```./UpdateModule.sh -skip-tests``` in the root directory of a module.