### PR TITLE
FW-1140: Scheduling Native Order Compute

### DIFF
--- a/FirstVoicesData/src/main/resources/data/schemas/fvdialect.xsd
+++ b/FirstVoicesData/src/main/resources/data/schemas/fvdialect.xsd
@@ -1,37 +1,58 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:nxs="http://www.nuxeo.org/ecm/project/schemas/First-Voices/fvdialect" xmlns:nxsv="http://www.nuxeo.org/ecm/schemas/core/validation/" xmlns:ref="http://www.nuxeo.org/ecm/schemas/core/external-references/" targetNamespace="http://www.nuxeo.org/ecm/project/schemas/First-Voices/fvdialect">  
-  <!-- helper XSD definitions for list types -->  
-  <xs:complexType name="content"> 
-    <xs:sequence> 
-      <xs:element name="encoding" type="xs:string"/>  
-      <xs:element name="mime-type" type="xs:string"/>  
-      <xs:element name="data" type="xs:base64Binary"/>  
-      <xs:element name="name" type="xs:string"/>  
-      <xs:element name="length" type="xs:long"/>  
-      <xs:element name="digest" type="xs:string"/> 
-    </xs:sequence> 
-  </xs:complexType>  
-  <xs:simpleType name="stringList"> 
-    <xs:list itemType="xs:string"/> 
-  </xs:simpleType>  
-  <xs:simpleType name="doubleList"> 
-    <xs:list itemType="xs:double"/> 
-  </xs:simpleType>  
-  <xs:simpleType name="dateList"> 
-    <xs:list itemType="xs:date"/> 
-  </xs:simpleType>  
-  <xs:simpleType name="integerList"> 
-    <xs:list itemType="xs:integer"/> 
-  </xs:simpleType>  
-  <xs:simpleType name="booleanList"> 
-    <xs:list itemType="xs:boolean"/> 
-  </xs:simpleType>  
-  <xs:complexType name="blobList"> 
-    <xs:sequence> 
-      <xs:element name="item" type="nxs:content" minOccurs="0" maxOccurs="unbounded"/> 
-    </xs:sequence> 
-  </xs:complexType>  
+<!--
+  ~ /*
+  ~ Copyright 2020 First People's Cultural Council
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~ */
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:nxs="http://www.nuxeo.org/ecm/project/schemas/First-Voices/fvdialect"
+           xmlns:ref="http://www.nuxeo.org/ecm/schemas/core/external-references/"
+           targetNamespace="http://www.nuxeo.org/ecm/project/schemas/First-Voices/fvdialect">
+  <!-- helper XSD definitions for list types -->
+  <xs:complexType name="content">
+    <xs:sequence>
+      <xs:element name="encoding" type="xs:string"/>
+      <xs:element name="mime-type" type="xs:string"/>
+      <xs:element name="data" type="xs:base64Binary"/>
+      <xs:element name="name" type="xs:string"/>
+      <xs:element name="length" type="xs:long"/>
+      <xs:element name="digest" type="xs:string"/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="stringList">
+    <xs:list itemType="xs:string"/>
+  </xs:simpleType>
+  <xs:simpleType name="doubleList">
+    <xs:list itemType="xs:double"/>
+  </xs:simpleType>
+  <xs:simpleType name="dateList">
+    <xs:list itemType="xs:date"/>
+  </xs:simpleType>
+  <xs:simpleType name="integerList">
+    <xs:list itemType="xs:integer"/>
+  </xs:simpleType>
+  <xs:simpleType name="booleanList">
+    <xs:list itemType="xs:boolean"/>
+  </xs:simpleType>
+  <xs:complexType name="blobList">
+    <xs:sequence>
+      <xs:element name="item" type="nxs:content" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
   <xs:element name="about_us" type="xs:string"/>
   <xs:element name="background_top_image" type="xs:string"/>
   <xs:element name="communities" type="xs:string"/>
@@ -87,4 +108,5 @@
   <xs:element name="region" type="xs:string"/>
   <xs:element name="related_links" type="nxs:stringList"/>
   <xs:element name="short_url" type="xs:string"/>
+  <xs:element name="last_native_order_recompute" type="xs:date"/>
 </xs:schema>

--- a/FirstVoicesPublisher/src/main/java/ca/firstvoices/schedulers/ComputeNativeOrderDialectsScheduler.java
+++ b/FirstVoicesPublisher/src/main/java/ca/firstvoices/schedulers/ComputeNativeOrderDialectsScheduler.java
@@ -1,0 +1,88 @@
+/*
+ *
+ * Copyright 2020 First People's Cultural Council
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+ */
+
+package ca.firstvoices.schedulers;
+
+import ca.firstvoices.nativeorder.services.NativeOrderComputeService;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.nuxeo.ecm.core.api.CoreSession;
+import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.api.DocumentModelList;
+import org.nuxeo.ecm.core.event.Event;
+import org.nuxeo.ecm.core.event.EventContext;
+import org.nuxeo.ecm.core.event.impl.DocumentEventContext;
+import org.nuxeo.runtime.api.Framework;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.EventListener;
+
+/**
+ * @author david
+ */
+public class ComputeNativeOrderDialectsScheduler implements EventListener {
+
+    private static final Log log = LogFactory.getLog(ComputeNativeOrderDialectsScheduler.class);
+
+
+    protected NativeOrderComputeService service = Framework.getService(NativeOrderComputeService.class);
+
+    public void handleEvent(Event event) {
+        EventContext ctx = event.getContext();
+        if (!(ctx instanceof DocumentEventContext)) {
+            return;
+        }
+
+        computeDialectsOnSchedule(ctx.getCoreSession());
+
+    }
+
+    public void computeDialectsOnSchedule(CoreSession session) {
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(new Date());
+        calendar.add(Calendar.DAY_OF_YEAR, -7);
+        String date = dateFormat.format(calendar.getTime());
+
+        // oldest/earliest dates to most recent
+        String query = "SELECT * FROM FVDialect "
+                + "WHERE fvdialect:last_native_order_recompute < DATE '"
+                + date + "'"
+                + " OR fvdialect:last_native_order_recompute IS NULL"
+                + " AND ecm:isVersion = 0  AND ecm:isTrashed = 0 AND ecm:isCheckedInVersion = 0 AND ecm:isProxy = 0"
+                + " ORDER BY fvdialect:last_native_order_recompute ASC";
+
+        DocumentModelList dialects = session.query(query);
+
+
+        // Process only a subset of items each night:
+        for (int i = 0, dialectsSize = dialects.size(); i < (Math.min(dialectsSize, 5)); i++) {
+            DocumentModel dialect = dialects.get(i);
+            try {
+                service.computeDialectNativeOrderTranslation(dialect);
+            } catch (Exception e) {
+                log.error(e);
+            }
+        }
+
+        session.save();
+    }
+}

--- a/FirstVoicesPublisher/src/main/resources/META-INF/MANIFEST.MF
+++ b/FirstVoicesPublisher/src/main/resources/META-INF/MANIFEST.MF
@@ -15,4 +15,4 @@ Nuxeo-Component: OSGI-INF/extensions/ca.firstvoices.templates.factorie
  extensions/ca.firstvoices.nativeorder.services.xml,OSGI-INF/extension
  s/ca.firstvoices.nativeorder.listeners.xml,OSGI-INF/extensions/ca.fir
  stvoices.nativeorder.actions.xml,OSGI-INF/extensions/ca.firstvoices.s
- ervices.xml,OSGI-INF/extensions/ca.firstvoices.operations.xml
+ ervices.xml,OSGI-INF/extensions/ca.firstvoices.operations.xml,OSGI-INF/extensions/ca.firstvoices.nativeorder.computeschedule.xml

--- a/FirstVoicesPublisher/src/main/resources/OSGI-INF/extensions/ca.firstvoices.nativeorder.computeschedule.xml
+++ b/FirstVoicesPublisher/src/main/resources/OSGI-INF/extensions/ca.firstvoices.nativeorder.computeschedule.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0"?>
 <!--
   ~ /*
   ~ Copyright 2020 First People's Cultural Council
@@ -17,14 +16,16 @@
   ~ */
   -->
 
-<component name="ca.firstvoices.nativeorder.computeschedule">
+<component name="ca.firstvoices.nativeorder.computeschedule.contrib">
     <require>ca.firstvoices.nativeorder.services.NativeOrderComputeServiceImpl</require>
 
     <extension target="org.nuxeo.ecm.core.scheduler.SchedulerService" point="schedule">
         <schedule id="computeNativeOrderSchedule">
-            <eventId>computeNativeOrderSchedule</eventId>
+            <eventId>computeNativeOrder</eventId>
             <eventCategory>default</eventCategory>
-            <cronExpression>0 0/1 0 ? * * *</cronExpression>
+            <!-- Everyday at 3 AM -->
+            <cronExpression>0 0 3 * * ?</cronExpression>
+            <username>Administrator</username>
         </schedule>
     </extension>
 </component>

--- a/FirstVoicesPublisher/src/main/resources/OSGI-INF/extensions/ca.firstvoices.nativeorder.computeschedule.xml
+++ b/FirstVoicesPublisher/src/main/resources/OSGI-INF/extensions/ca.firstvoices.nativeorder.computeschedule.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!--
+  ~ /*
+  ~ Copyright 2020 First People's Cultural Council
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~ */
+  -->
+
+<component>
+    <extension target="org.nuxeo.ecm.core.scheduler.SchedulerService" point="schedule">
+        <schedule id="compute_nativeorder_schedule">
+            <eventId>computeNativeOrderSchedule</eventId>
+            <eventCategory>default</eventCategory>
+            <!-- Every day at 3:15 AM -->
+            <cronExpression>0 15 3 * * ?</cronExpression>
+        </schedule>
+    </extension>
+</component>

--- a/FirstVoicesPublisher/src/main/resources/OSGI-INF/extensions/ca.firstvoices.nativeorder.computeschedule.xml
+++ b/FirstVoicesPublisher/src/main/resources/OSGI-INF/extensions/ca.firstvoices.nativeorder.computeschedule.xml
@@ -17,13 +17,14 @@
   ~ */
   -->
 
-<component>
+<component name="ca.firstvoices.nativeorder.computeschedule">
+    <require>ca.firstvoices.nativeorder.services.NativeOrderComputeServiceImpl</require>
+
     <extension target="org.nuxeo.ecm.core.scheduler.SchedulerService" point="schedule">
-        <schedule id="compute_nativeorder_schedule">
+        <schedule id="computeNativeOrderSchedule">
             <eventId>computeNativeOrderSchedule</eventId>
             <eventCategory>default</eventCategory>
-            <!-- Every day at 3:15 AM -->
-            <cronExpression>0 15 3 * * ?</cronExpression>
+            <cronExpression>0 0/1 0 ? * * *</cronExpression>
         </schedule>
     </extension>
 </component>

--- a/FirstVoicesPublisher/src/main/resources/OSGI-INF/extensions/ca.firstvoices.nativeorder.listeners.xml
+++ b/FirstVoicesPublisher/src/main/resources/OSGI-INF/extensions/ca.firstvoices.nativeorder.listeners.xml
@@ -1,3 +1,21 @@
+<!--
+  ~ /*
+  ~ Copyright 2020 First People's Cultural Council
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~ */
+  -->
+
 <component name="ca.firstvoices.nativeorder.listeners.listener.contrib.ComputeNativeOrderListener">
   <require>ca.firstvoices.nativeorder.services.NativeOrderComputeServiceImpl</require>
   <extension target="org.nuxeo.ecm.core.event.EventServiceComponent" point="listener">
@@ -7,15 +25,18 @@
       <event>beforeDocumentModification</event>
       <event>documentCreated</event>
     </listener>
-    
+
     <listener name="ComputeNativeOrderAlphabetListener" postCommit="false" async="false"
-      class="ca.firstvoices.nativeorder.listeners.ComputeNativeOrderAlphabetListener" priority="250">
+              class="ca.firstvoices.nativeorder.listeners.ComputeNativeOrderAlphabetListener" priority="250">
       <event>beforeDocumentModification</event>
       <event>documentModified</event>
       <event>documentTrashed</event>
       <event>documentUntrashed</event>
     </listener>
-    
-  </extension>
 
+
+    <listener name="ComputeNativeOrderScheduler" async="true" postCommit="false"
+              priority="1000" class="ca.firstvoices.schedulers.ComputeNativeOrderDialectsScheduler">
+    </listener>
+  </extension>
 </component>

--- a/FirstVoicesPublisher/src/test/java/ca/firstvoices/listeners/FirstVoicesNativeOrderTest.java
+++ b/FirstVoicesPublisher/src/test/java/ca/firstvoices/listeners/FirstVoicesNativeOrderTest.java
@@ -23,7 +23,6 @@ import ca.firstvoices.nativeorder.services.NativeOrderComputeService;
 import ca.firstvoices.schedulers.ComputeNativeOrderDialectsScheduler;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.nuxeo.ecm.core.api.CoreSession;
@@ -37,9 +36,8 @@ import org.nuxeo.runtime.test.runner.Features;
 import org.nuxeo.runtime.test.runner.FeaturesRunner;
 
 import javax.inject.Inject;
-import java.text.SimpleDateFormat;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 /**
  * @author loopingz
@@ -315,20 +313,21 @@ public class FirstVoicesNativeOrderTest {
     }
 
     @Test
-    @Ignore
-    //    TODO: Finish Unit Test
     public void testcomputeNativeOrderDialectsScheduler() {
-        String pattern = "yyyy-MM-dd";
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat(pattern);
-
         DocumentModel di2 = createDocument(session.createDocumentModel("/Family/Language", "Dialect2", "FVDialect"));
         DocumentModel di3 = createDocument(session.createDocumentModel("/Family/Language", "Dialect3", "FVDialect"));
         DocumentModel di4 = createDocument(session.createDocumentModel("/Family/Language", "Dialect4", "FVDialect"));
         DocumentModel di5 = createDocument(session.createDocumentModel("/Family/Language", "Dialect5", "FVDialect"));
 
-        computeNativeOrderDialectsScheduler.computeDialectsOnSchedule(session);
-        session.save();
+        assertNull(dialect.getPropertyValue("last_native_order_recompute"));
+        assertNull(di2.getPropertyValue("last_native_order_recompute"));
+        assertNull(di3.getPropertyValue("last_native_order_recompute"));
+        assertNull(di4.getPropertyValue("last_native_order_recompute"));
+        assertNull(di5.getPropertyValue("last_native_order_recompute"));
 
+        DocumentModelList dialects = computeNativeOrderDialectsScheduler.computeDialectsOnSchedule(session);
+
+        dialects.forEach(dialect -> assertNotNull(dialect.getPropertyValue("last_native_order_recompute")));
     }
 
     private DocumentModel createDocument(DocumentModel model) {


### PR DESCRIPTION
Playing around with schedulers. In this example, everyday at 3AM, Nuxeo will pull all the dialects and will recompute the custom order for 5 of them.

To test this locally, you can change the cron expression here: 
https://github.com/First-Peoples-Cultural-Council/fv-web-ui/pull/245/files#diff-69e19f550b6447a7d95867396d5a1e89R27

To a custom cron expression (such as every 30 seconds) and use local debugger to see event fired. 

You can use this tool to debug:
https://www.freeformatter.com/cron-expression-generator-quartz.html#cronexpressionexamples
