### PR TITLE
FW-1278 Adjustments to docker container for Ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM node:10.19.0 AS build
 WORKDIR /app
 ENV PATH /app/node_modules/.bin:$PATH
 ENV GIT_DISCOVERY_ACROSS_FILESYSTEM=1
+ENV DEBIAN_FRONTEND=noninteractive
 COPY frontend /app
 COPY .git /.git
 RUN apt-get update && apt-get install -y libgl1-mesa-dev
@@ -20,7 +21,6 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
         pwgen \
         imagemagick \
         ffmpeg2theora \
-        ufraw \
         poppler-utils \
         libwpd-tools \
         exiftool \

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,7 +11,8 @@ This environment is setup for localhost work. It includes:
 
 1. You must have Docker installed and running with at least 4GB of memory allocated to docker (preferrably more), as well as git installed. Docker can be downloaded from [this link](https://docs.docker.com/install/) and git can be downloaded from [this link](https://git-scm.com/downloads). You will also need the following dependencies:
 
-   - Java 8 (jdk 1.8.0_xxx [openjdk recommended](https://openjdk.java.net/install/))
+   - Java 8 JDK (jdk 1.8.0_xxx [openjdk recommended](https://openjdk.java.net/install/))
+     * Don't forget to set JAVA_HOME to the path to the JDK install
    - [Apache Maven v3.6.3](https://maven.apache.org/)
    - NodeJS v10.19.0 ([node version manager recommended](https://github.com/nvm-sh/nvm))
    - NPM v6.13.4 ([node version manager recommended](https://github.com/nvm-sh/nvm))


### PR DESCRIPTION
- Removed `ufraw` library from docker image build since it is not available on Ubuntu 20.04

- Added `ENV DEBIAN_FRONTEND=noninteractive` to address timezone library interaction requirement.

- Added more info to Java install in README