### PR TITLE
FW-1294: Unpublished changes based on diff

### DIFF
--- a/FirstVoices-marketplace/src/main/assemble/assembly.xml
+++ b/FirstVoices-marketplace/src/main/assemble/assembly.xml
@@ -23,9 +23,23 @@
       <artifact:set excludeRoots="true">
         <includes>
           <artifact groupId="ca.firstvoices*" scope="" type="!pom" />
-<!--          <artifact groupId="nuxeo-studio" scope="" type="!pom" />-->
         </includes>
       </artifact:set>
+    </copy>
+
+    <!-- Third-party libraries -->
+    <!-- See here for more details: https://github.com/nuxeo/ant-assembly-maven-plugin-->
+    <copy todir="${outdir}/marketplace/install/lib" overwrite="true">
+
+      <!-- Include javers-core and related dependencies as JARs to be deployed -->
+      <artifact:file artifactId="javers-core"/>
+      <artifact:dependencies artifactId="javers-core">
+        <excludes>
+          <artifact scope="test"/>
+          <artifact scope="provided"/>
+        </excludes>
+      </artifact:dependencies>
+
     </copy>
 
     <zip destfile="${outdir}/${maven.project.artifactId}-${maven.project.version}.zip"

--- a/FirstVoices-marketplace/src/main/resources/install.xml
+++ b/FirstVoices-marketplace/src/main/resources/install.xml
@@ -1,6 +1,7 @@
 <!-- See documentation at http://doc.nuxeo.com/x/IgIz -->
 <install>
   <update file="${package.root}/install/bundles" todir="${env.bundles}" />
+  <update file="${package.root}/install/lib" todir="${env.lib}" />
   <copy dir="${package.root}/install/templates" todir="${env.templates}" overwrite="true" />
   <config addtemplate="first-voices" />
 </install>

--- a/FirstVoicesDraftEditor/pom.xml
+++ b/FirstVoicesDraftEditor/pom.xml
@@ -171,26 +171,5 @@
         <enabled>true</enabled>
       </snapshots>
     </repository>
-    <repository>
-      <id>hotfix-releases</id>
-      <url>https://maven.nuxeo.org/nexus/content/repositories/hotfix-releases</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>hotfix-snapshots</id>
-      <url>https://maven.nuxeo.org/nexus/content/repositories/hotfix-snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <updatePolicy>always</updatePolicy>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
   </repositories>
 </project>

--- a/FirstVoicesPublisher/pom.xml
+++ b/FirstVoicesPublisher/pom.xml
@@ -39,6 +39,11 @@
       <artifactId>nuxeo-core-schema</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.javers</groupId>
+      <artifactId>javers-core</artifactId>
+      <version>5.8.13</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
       <scope>test</scope>

--- a/FirstVoicesPublisher/src/main/java/ca/firstvoices/operations/CheckUnpublishedChanges.java
+++ b/FirstVoicesPublisher/src/main/java/ca/firstvoices/operations/CheckUnpublishedChanges.java
@@ -29,5 +29,4 @@ public class CheckUnpublishedChanges {
         // Call the checkUnpublishedChanges service which returns true if a document has unpublished changes and false otherwise.
         return service.checkUnpublishedChanges(session, input);
     }
-
 }

--- a/FirstVoicesPublisher/src/main/java/ca/firstvoices/operations/GetUnpublishedChanges.java
+++ b/FirstVoicesPublisher/src/main/java/ca/firstvoices/operations/GetUnpublishedChanges.java
@@ -1,0 +1,60 @@
+package ca.firstvoices.operations;
+
+import ca.firstvoices.services.UnpublishedChangesService;
+import org.javers.core.JaversBuilder;
+import org.javers.core.diff.Diff;
+import org.json.JSONObject;
+import org.nuxeo.ecm.automation.core.Constants;
+import org.nuxeo.ecm.automation.core.annotations.Operation;
+import org.nuxeo.ecm.automation.core.annotations.OperationMethod;
+import org.nuxeo.ecm.core.api.Blob;
+import org.nuxeo.ecm.core.api.CoreSession;
+import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.api.impl.blob.JSONBlob;
+import org.nuxeo.ecm.core.api.impl.blob.StringBlob;
+import org.nuxeo.runtime.api.Framework;
+
+/**
+ *
+ */
+@Operation(id= GetUnpublishedChanges.ID, category= Constants.CAT_DOCUMENT, label="FVGetUnpublishedChanges",
+        description="This operation is used to get the unpublished changes for the document. " +
+                "It returns a list of changes if unpublished changes exist.")
+public class GetUnpublishedChanges {
+
+    CoreSession session;
+
+    public static final String ID = "Document.GetUnpublishedChanges";
+
+    protected UnpublishedChangesService service = Framework.getService(UnpublishedChangesService.class);
+
+    @OperationMethod
+    public Blob run(DocumentModel input) {
+
+        JSONObject response = new JSONObject();
+
+        session = input.getCoreSession();
+        Diff diff = service.getUnpublishedChanges(session, input);
+
+        if (!diff.hasChanges()) {
+            return new StringBlob("", "application/json");
+        }
+
+        Object jsonDiff = JaversBuilder.javers().build().getJsonConverter().toJson(diff);
+        return new JSONBlob(jsonDiff.toString());
+    }
+
+//    // Untested: Potentially a method for comparing two arbitrary documents (probably better to get these two docs as two doc id parameters)
+//    @OperationMethod
+//    public String run(DocumentModelList docs) throws IOException {
+//
+//        if (docs.size() > 2) {
+//            throw new IOException("Only 2 docs for comparison are allowed");
+//        }
+//
+//        session = docs.get(0).getCoreSession();
+//        Diff diff = service.getChanges(session, docs.get(0), docs.get(1));
+//
+//        return diff.prettyPrint();
+//    }
+}

--- a/FirstVoicesPublisher/src/main/java/ca/firstvoices/services/UnpublishedChangesService.java
+++ b/FirstVoicesPublisher/src/main/java/ca/firstvoices/services/UnpublishedChangesService.java
@@ -1,5 +1,6 @@
 package ca.firstvoices.services;
 
+import org.javers.core.diff.Diff;
 import org.nuxeo.ecm.core.api.CoreSession;
 import org.nuxeo.ecm.core.api.DocumentModel;
 
@@ -10,5 +11,11 @@ public interface UnpublishedChangesService {
         Returns false otherwise.
      */
     boolean checkUnpublishedChanges(CoreSession session, DocumentModel document);
+
+    /*
+        Method that returns the changes between a document and it's unpublished version
+        Return nothing otherwise
+     */
+    Diff getUnpublishedChanges(CoreSession session, DocumentModel document);
 
 }

--- a/FirstVoicesPublisher/src/main/java/ca/firstvoices/services/UnpublishedChangesServiceImpl.java
+++ b/FirstVoicesPublisher/src/main/java/ca/firstvoices/services/UnpublishedChangesServiceImpl.java
@@ -1,62 +1,121 @@
 package ca.firstvoices.services;
 
 import ca.firstvoices.publisher.services.FirstVoicesPublisherService;
+import org.javers.core.Javers;
+import org.javers.core.JaversBuilder;
+import org.javers.core.diff.Diff;
 import org.nuxeo.ecm.core.api.CoreInstance;
-import org.nuxeo.ecm.core.api.DocumentModel;
-import org.nuxeo.ecm.core.api.DocumentRef;
-import org.nuxeo.ecm.core.schema.DocumentType;
 import org.nuxeo.ecm.core.api.CoreSession;
+import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.schema.DocumentType;
 import org.nuxeo.runtime.api.Framework;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class UnpublishedChangesServiceImpl implements UnpublishedChangesService {
-    
+
     public boolean checkUnpublishedChanges(CoreSession session, DocumentModel document) {
-    
+        Diff diff = getUnpublishedChanges(session, document);
+
+        if (diff == null) {
+            return false;
+        }
+
+        return diff.hasChanges();
+    }
+
+    public Diff getUnpublishedChanges(CoreSession session, DocumentModel document) {
         FirstVoicesPublisherService FVPublisherService = Framework.getService(FirstVoicesPublisherService.class);
-        
+
         // Check that the document is a specific type using the helper method
         if (!(checkType(document)))
-            return false;
-    
+            return null;
+
         // Check that the document is currently published
         if (! document.getCurrentLifeCycleState().equals("Published")) {
-            return false;
+            return null;
         }
 
         /*
              A privileged session is used to get the workspaces doc ref and versions in case the
              service is being called from a place that does not have access to the workspaces document.
         */
-        DocumentRef workspacesDocRef = CoreInstance.doPrivileged(session, s -> {
-            return s.getSourceDocument(document.getRef()).getRef();
+        DocumentModel workspacesDoc = CoreInstance.doPrivileged(session, s -> {
+            return s.getSourceDocument(document.getRef());
         });
-        
-        int majorVerDoc = CoreInstance.doPrivileged(session, s -> {
-            return Integer.parseInt(s.getWorkingCopy(document.getRef()).getPropertyValue("uid:major_version").toString());
-        });
-        int minorVerDoc = CoreInstance.doPrivileged(session, s -> {
-            return Integer.parseInt(s.getWorkingCopy(document.getRef()).getPropertyValue("uid:minor_version").toString());
-        });
-        
+
         // Get the sections document and versions
-        DocumentModel sectionsDoc = FVPublisherService.getPublication(session, workspacesDocRef);
-        int majorVerSections =  Integer.parseInt(sectionsDoc.getPropertyValue("uid:major_version").toString());
-        int minorVerSections =  Integer.parseInt(sectionsDoc.getPropertyValue("uid:minor_version").toString());
-        
-        /*
-                Use the helper method to compare versions of the document and return true if the sections
-                version is older then the workspaces version.
-            */
-        return compareVersions(majorVerDoc, minorVerDoc, majorVerSections, minorVerSections);
+        DocumentModel sectionsDoc = FVPublisherService.getPublication(session, workspacesDoc.getRef());
+
+        return compareDocs(sectionsDoc, workspacesDoc);
     }
 
-    // Helper method to check if the workspaces document version is greater then then sections document version
-    private boolean compareVersions(int majorVerDoc, int minorVerDoc, int majorVerSections, int minorVerSections) {
-        if (majorVerDoc > majorVerSections) {
-            return true;
-        } else return majorVerDoc == majorVerSections && minorVerDoc > minorVerSections;
+    // Note: This is unrelated to publisher - will diff any two objects. Could potentially move to another package.
+    public Diff getChanges(CoreSession session, DocumentModel leftDocument, DocumentModel rightDocument) {
+        // Check that the document is a specific type using the helper method
+        if (!(checkType(leftDocument)) || !(checkType(rightDocument)))
+            return null;
+
+        return compareDocs(leftDocument, rightDocument);
+    }
+
+    private Diff compareDocs(DocumentModel leftDoc, DocumentModel rightDoc) {
+
+        // Get all properties for all schemas (left doc)
+        Map<String, Object> leftDocAllProps = getDiffProperties(leftDoc);
+
+        // Get all relevant properties (right doc)
+        Map<String, Object> rightDocAllProps = getDiffProperties(rightDoc);
+
+        // Setup javers for diff
+        Javers javers = JaversBuilder.javers().build();
+
+        // Compare left doc and right doc
+        return javers.compare(leftDocAllProps, rightDocAllProps);
+    }
+
+    // Helper method to get all relevant properties for the diff
+    private HashMap<String, Object> getDiffProperties(DocumentModel doc) {
+
+        // The following schemas shouldn't be considered in a diff (they are not user-controlled)
+        String[] excludedSchemas = {"uid", "collectionMember", "common", "fvancestry", "fvproxy", "fvlegacy", "relatedtext", "facetedTag"};
+        List<String> excludedSchemasList = Arrays.asList(excludedSchemas);
+
+        // The follow properties shouldn't be considered in a diff (they are not user-controlled)
+        String[] excludedProperties = {"dc:modified", "dc:created", "dc:contributors", "dc:lastContributor"};
+        List<String> excludedPropertiesList = Arrays.asList(excludedProperties);
+
+        Map<String, Object> relevantProperties = new HashMap<>();
+
+        for (String schema : doc.getSchemas()) {
+            if (excludedSchemasList.contains(schema)) {
+                continue;
+            }
+
+            relevantProperties.putAll(doc.getProperties(schema));
+        }
+
+        // Filter out excluded properties and process conversions
+        return (HashMap<String, Object>) relevantProperties.entrySet().stream()
+                .filter(e -> !excludedPropertiesList.contains(e.getKey())) // Filter out excluded properties
+                .collect(Collectors.toMap( t -> t.getKey(), t->convertDiffFields(t.getValue()) ));
+    }
+
+    // Helper method to convert certain types that are hard to compare (e.g. String list) to comparable types
+    private Object convertDiffFields(Object field) {
+        if (field == null) {
+            return new String("");
+        }
+
+        if (field instanceof String[]) {
+            return Arrays.toString((String[]) field);
+        }
+
+        return field;
     }
 
     // Helper method to check that the new document is one of the types below

--- a/FirstVoicesPublisher/src/main/java/ca/firstvoices/services/UnpublishedChangesServiceImpl.java
+++ b/FirstVoicesPublisher/src/main/java/ca/firstvoices/services/UnpublishedChangesServiceImpl.java
@@ -86,7 +86,7 @@ public class UnpublishedChangesServiceImpl implements UnpublishedChangesService 
         List<String> excludedSchemasList = Arrays.asList(excludedSchemas);
 
         // The follow properties shouldn't be considered in a diff (they are not user-controlled)
-        String[] excludedProperties = {"dc:modified", "dc:created", "dc:contributors", "dc:lastContributor"};
+        String[] excludedProperties = {"dc:modified", "dc:created", "dc:contributors", "dc:lastContributor", "fv-alphabet:update_confusables_required", "fv-phrase:update_confusables_required", "fv-word:update_confusables_required", "fv-alphabet:custom_order_recompute_required"};
         List<String> excludedPropertiesList = Arrays.asList(excludedProperties);
 
         Map<String, Object> relevantProperties = new HashMap<>();

--- a/FirstVoicesPublisher/src/main/resources/OSGI-INF/extensions/ca.firstvoices.operations.xml
+++ b/FirstVoicesPublisher/src/main/resources/OSGI-INF/extensions/ca.firstvoices.operations.xml
@@ -3,6 +3,7 @@
 
   <extension point="operations" target="org.nuxeo.ecm.core.operation.OperationServiceComponent">
     <operation class="ca.firstvoices.operations.CheckUnpublishedChanges"/>
+    <operation class="ca.firstvoices.operations.GetUnpublishedChanges"/>
   </extension>
 
 </component>

--- a/docker/README.md
+++ b/docker/README.md
@@ -129,6 +129,15 @@ You should now see your new FirstVoices language archive when you access the fro
 
 These are not required for getting started, but contain some useful information if you wish to modify the environment for your needs.
 
+### Allotting enough resources to Docker
+
+Make sure your Docker Environment (e.g. [Docker engine on Mac](https://docs.docker.com/docker-for-mac/space/)) has enough memory. Elasticsearch [recommends 4 GB](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html) at the very least.
+
+### Clearing your existing containers and dealing with cache
+
+* If you encounter issues with remaining artifacts from previous runs, [you can clear some of those](https://github.com/moby/moby/issues/23371#issuecomment-224927009). Remember that these commands will clear ALL your docker artifacts, not just ones created as part of this project.
+* If you wish to build a docker image with no cache (force a rebuild), add the `--no-cache` flag.   
+
 ### Manually running the initial setup script
 
 This should not be required, but if you need to run it manually, you can do so by running the following command from the docker directory:

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,6 @@
 
   <properties>
     <nuxeo.distribution.version>10.10</nuxeo.distribution.version>
-    <fv.studio.version>3.1.6</fv.studio.version>
   </properties>
 
   <parent>
@@ -138,27 +137,6 @@
       </releases>
       <snapshots>
         <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>hotfix-releases</id>
-      <url>https://maven.nuxeo.org/nexus/content/repositories/hotfix-releases</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-    <repository>
-      <id>hotfix-snapshots</id>
-      <url>https://maven.nuxeo.org/nexus/content/repositories/hotfix-snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <updatePolicy>always</updatePolicy>
-        <enabled>true</enabled>
       </snapshots>
     </repository>
   </repositories>


### PR DESCRIPTION
Notes:

- Document.CheckUnpublishedChanges: Rather than evaluating the version of documents, the service was updated to do a diff, excluding properties and schemas that are not likely to be updated by end-users. We will need to adjust this as we introduce new schemas that are not user facing.

- Document.GetUnpublishedChanges: This is a new end-point that will actually display the diff between the two documents.

This change introduces a new external library (https://javers.org/)