### PR TITLE
FW-1329

### DIFF
--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/index.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/index.js
@@ -223,8 +223,12 @@ export class PageDialectLearnPhrases extends PageDialectLearnBase {
       [dialect]
     )
     const { DEFAULT_PAGE, DEFAULT_PAGE_SIZE } = this._getURLPageProps() // NOTE: This function is in PageDialectLearnBase
+    const dialectId = selectn(
+      'response.contextParameters.ancestry.dialect.uid',
+      ProviderHelpers.getEntry(this.props.computeDocument, this.props.routeParams.dialect_path + '/Dictionary')
+    )
     const phraseListView =
-      selectn('response.uid', computeDocument) && this.state.dialectId ? (
+      selectn('response.uid', computeDocument) && dialectId ? (
         <PhraseListView
           controlViaURL
           DEFAULT_PAGE_SIZE={DEFAULT_PAGE_SIZE}
@@ -235,7 +239,7 @@ export class PageDialectLearnPhrases extends PageDialectLearnBase {
           flashcardTitle={pageTitle}
           onPagePropertiesChange={this._handlePagePropertiesChange} // NOTE: This function is in PageDialectLearnBase
           parentID={selectn('response.uid', computeDocument)}
-          dialectID={this.state.dialectId}
+          dialectID={dialectId}
           routeParams={this.props.routeParams}
           // Search:
           handleSearch={this.handleSearch}

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/index.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/index.js
@@ -126,10 +126,6 @@ export class PageDialectLearnPhrases extends PageDialectLearnBase {
     const newState = {
       characters,
       phraseBooks,
-      dialectId: selectn(
-        'response.contextParameters.ancestry.dialect.uid',
-        ProviderHelpers.getEntry(this.props.computeDocument, routeParams.dialect_path + '/Dictionary')
-      ),
     }
 
     // Clear out filterInfo if not in url, eg: /learn/words/categories/[category]

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/index.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/index.js
@@ -112,10 +112,6 @@ class PageDialectLearnWords extends PageDialectLearnBase {
 
     const newState = {
       characters,
-      dialectId: selectn(
-        'response.contextParameters.ancestry.dialect.uid',
-        ProviderHelpers.getEntry(this.props.computeDocument, routeParams.dialect_path + '/Dictionary')
-      ),
     }
 
     // Clear out filterInfo if not in url, eg: /learn/words/categories/[category]
@@ -203,8 +199,12 @@ class PageDialectLearnWords extends PageDialectLearnBase {
     const { DEFAULT_SORT_COL, DEFAULT_SORT_TYPE } = searchNxqlSort
     const { DEFAULT_PAGE, DEFAULT_PAGE_SIZE } = this._getURLPageProps() // NOTE: This function is in PageDialectLearnBase
 
+    const dialectId = selectn(
+      'response.contextParameters.ancestry.dialect.uid',
+      ProviderHelpers.getEntry(this.props.computeDocument, this.props.routeParams.dialect_path + '/Dictionary')
+    )
     const wordListView =
-      selectn('response.uid', computeDocument) && this.state.dialectId ? (
+      selectn('response.uid', computeDocument) && dialectId ? (
         <WordListView
           controlViaURL
           DEFAULT_PAGE={DEFAULT_PAGE}
@@ -216,7 +216,7 @@ class PageDialectLearnWords extends PageDialectLearnBase {
           flashcard={this.state.flashcardMode}
           flashcardTitle={pageTitle}
           parentID={selectn('response.uid', computeDocument)}
-          dialectID={this.state.dialectId}
+          dialectID={dialectId}
           routeParams={this.props.routeParams}
           // Search:
           handleSearch={this.handleSearch}


### PR DESCRIPTION
On the words page the dialectId set in componentDidMount would be undefined when revisiting pages

Moved accessing the dialect id into the render function and that fixed the issue

Updated phrases to follow the same pattern for consistency (though phrases did not display the same issue)