### PR TITLE
FW-1421 Extract changes related to DialectFilterListData from the `FW-1234-v2` branch

### DIFF
--- a/frontend/app/assets/javascripts/views/components/DialectFilterList/DialectFilterList.css
+++ b/frontend/app/assets/javascripts/views/components/DialectFilterList/DialectFilterList.css
@@ -1,9 +1,9 @@
-// BLOCK
+/* BLOCK */
 .DialectFilterList {
   font-size: 16px;
   line-height: 1.2;
 }
-// ELEMENT
+/* ELEMENT */
 .DialectFilterListItemGroup {
   display: flex;
   width: 100%;
@@ -37,7 +37,7 @@
 .DialectFilterListLink:focus {
   text-decoration: underline;
 }
-// MODIFIERS
+/* MODIFIERS */
 .DialectFilterListLink--child {
   padding-left: 35px;
 }
@@ -58,7 +58,7 @@ a.DialectFilterListLink--activeParent:hover {
   border-left: 3px solid #820000;
 }
 
-@media (max-width: @medium-screen) {
+@media (max-width: 991px) {
   .DialectFilterListLink {
     padding: 5px;
   }

--- a/frontend/app/assets/javascripts/views/components/DialectFilterList/DialectFilterListData.js
+++ b/frontend/app/assets/javascripts/views/components/DialectFilterList/DialectFilterListData.js
@@ -89,8 +89,9 @@ class DialectFilterListData extends Component {
     const { facets } = this.state
     const { facets: prevFacets } = prevState
 
-    const prevAppliedFilterIds = prevProps.appliedFilterIds
-    const currentAppliedFilterIds = this.props.appliedFilterIds
+    // Note: guard against undefined
+    const prevAppliedFilterIds = prevProps.appliedFilterIds || new Set()
+    const currentAppliedFilterIds = this.props.appliedFilterIds || new Set()
 
     if (prevFacets.length !== facets.length) {
       this.filtersSorted = this.sortDialectFilters(facets)
@@ -316,7 +317,7 @@ DialectFilterListData.propTypes = {
   dialectFilterListWillUnmount: func,
   path: string.isRequired, // Used with facets
   setDialectFilter: func,
-  type: string.isRequired,
+  type: string,
   workspaceKey: string.isRequired, // Used with facetField
   // REDUX: reducers/state
   computeCategories: object.isRequired,
@@ -326,6 +327,7 @@ DialectFilterListData.propTypes = {
   fetchCategories: func.isRequired,
 }
 DialectFilterListData.defaultProps = {
+  appliedFilterIds: new Set(),
   dialectFilterListWillUnmount: () => {},
   setDialectFilter: () => {},
 }

--- a/frontend/app/assets/javascripts/views/components/DialectFilterList/DialectFilterListData.js
+++ b/frontend/app/assets/javascripts/views/components/DialectFilterList/DialectFilterListData.js
@@ -1,0 +1,350 @@
+import { Component } from 'react'
+import { connect } from 'react-redux'
+import { Set } from 'immutable'
+import PropTypes from 'prop-types'
+import ProviderHelpers from 'common/ProviderHelpers'
+import selectn from 'selectn'
+// REDUX: actions/dispatch/func
+import { fetchCategories } from 'providers/redux/reducers/fvCategory'
+
+class DialectFilterListData extends Component {
+  historyData = {}
+  filtersSorted = []
+  selectedDialectFilter = undefined
+
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      facets: [],
+      facetField: ProviderHelpers.switchWorkspaceSectionKeys(props.workspaceKey, this.props.routeParams.area),
+      lastCheckedUid: undefined,
+      lastCheckedChildrenUids: [],
+      lastCheckedParentFacetUid: undefined,
+    }
+  }
+  async componentDidMount() {
+    const { path, type } = this.props
+    // Get categories
+    await ProviderHelpers.fetchIfMissing(path, this.props.fetchCategories, this.props.computeCategories)
+    const extractComputedCategories = ProviderHelpers.getEntry(this.props.computeCategories, path)
+    const facets = selectn('response.entries', extractComputedCategories)
+
+    // Bind history events
+    window.addEventListener('popstate', this.handleHistoryEvent)
+
+    // Is something selected? (via url)
+    const selectedDialectFilter =
+      type === 'words' ? selectn('category', this.props.routeParams) : selectn('phraseBook', this.props.routeParams)
+
+    if (selectedDialectFilter) {
+      this.selectedDialectFilter = selectedDialectFilter
+    }
+
+    // we have data, so...
+    if (facets && facets.length > 0) {
+      this.filtersSorted = this.sortDialectFilters(facets)
+      this.generateClickParamData(this.filtersSorted)
+    }
+
+    this.setState(
+      {
+        facets,
+      },
+      () => {
+        if (this.selectedDialectFilter) {
+          const selectedParams = this.historyData[this.selectedDialectFilter]
+          if (selectedParams) {
+            this.setSelected(selectedParams)
+            this.selectedDialectFilter = undefined
+          }
+        }
+      }
+    )
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('popstate', this.handleHistoryEvent)
+
+    // NOTE: Believe this stuff is legacy from a previous version of the category sidebar
+    // that could select multiple items. May be able to toss it but not 100% sure.
+    const { lastCheckedUid, lastCheckedChildrenUids, lastCheckedParentFacetUid } = this.state
+    // 'uncheck' previous
+    if (lastCheckedUid) {
+      const unselected = {
+        checkedFacetUid: lastCheckedUid,
+        childrenIds: lastCheckedChildrenUids,
+        parentFacetUid: lastCheckedParentFacetUid,
+      }
+      this.props.dialectFilterListWillUnmount({
+        facetField: this.state.facetField,
+        unselected,
+        type: this.props.type,
+        resetUrlPagination: false,
+      })
+    }
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    const { facets } = this.state
+    const { facets: prevFacets } = prevState
+
+    const prevAppliedFilterIds = prevProps.appliedFilterIds
+    const currentAppliedFilterIds = this.props.appliedFilterIds
+
+    if (prevFacets.length !== facets.length) {
+      this.filtersSorted = this.sortDialectFilters(facets)
+    }
+
+    if (prevFacets.length !== facets.length || prevAppliedFilterIds.equals(currentAppliedFilterIds) === false) {
+      this.generateClickParamData(this.filtersSorted)
+    }
+  }
+
+  render() {
+    return this.props.children({
+      facetField: this.state.facetField,
+      facets: this.state.facets,
+      routeParams: this.props.routeParams,
+      facetSelected: this.props.routeParams.category,
+
+      listItemsData: this.generateListItemData(),
+
+      lastCheckedUid: this.state.lastCheckedUid,
+      lastCheckedChildrenUids: this.state.lastCheckedChildrenUids,
+      lastCheckedParentFacetUid: this.state.lastCheckedParentFacetUid,
+    })
+  }
+
+  generateDialectFilterUrl = (filterId) => {
+    let href = `/${this.props.splitWindowPath.join('/')}`
+    const _splitWindowPath = [...this.props.splitWindowPath]
+    const wordOrPhraseIndex = _splitWindowPath.findIndex((element) => {
+      return element === 'words' || element === 'phrases'
+    })
+    if (wordOrPhraseIndex !== -1) {
+      _splitWindowPath.splice(wordOrPhraseIndex + 1)
+      const urlFragment = this.props.type === 'words' ? 'categories' : 'book'
+      href = `/${_splitWindowPath.join('/')}/${urlFragment}/${filterId}`
+    }
+    return href
+  }
+
+  // Generates data structure representing the list
+  generateListItemData = () => {
+    const { appliedFilterIds } = this.props
+
+    const listItemData = []
+    this.filtersSorted.forEach((filter) => {
+      const childData = []
+      const uidParent = filter.uid
+
+      // Process children
+      const children = selectn('contextParameters.children.entries', filter)
+      const parentIsActive = appliedFilterIds.includes(uidParent)
+      let hasActiveChild = false
+
+      if (children.length > 0) {
+        children.forEach((filterChild) => {
+          const uidChild = filterChild.uid
+          const childIsActive = appliedFilterIds.includes(uidChild)
+          // Set flag for parent processing
+          hasActiveChild = childIsActive
+          // Save child data
+          childData.push({
+            uid: uidChild,
+            href: this.generateDialectFilterUrl(uidChild),
+            isActive: childIsActive,
+            hasActiveParent: parentIsActive,
+            text: filterChild.title,
+          })
+        })
+      }
+
+      // Process parent
+      listItemData.push({
+        uid: uidParent,
+        href: this.generateDialectFilterUrl(uidParent),
+        isActive: parentIsActive,
+        hasActiveChild: hasActiveChild,
+        text: filter.title,
+        children: childData,
+      })
+    })
+    return listItemData
+  }
+
+  // Generates data used with history events
+  generateClickParamData = (filters) => {
+    filters.forEach((filter) => {
+      const uidParent = filter.uid
+
+      // Process children
+      const childrenUids = []
+      const children = selectn('contextParameters.children.entries', filter)
+      if (children.length > 0) {
+        children.forEach((filterChild) => {
+          const uidChild = filterChild.uid
+
+          childrenUids.push(uidChild)
+
+          // Saving for history events
+          this.historyData[uidChild] = {
+            href: this.generateDialectFilterUrl(uidChild),
+            checkedFacetUid: uidChild,
+            childrenIds: null,
+            parentFacetUid: uidParent,
+          }
+        })
+      }
+
+      // Process parent
+      const parentClickParams = {
+        href: this.generateDialectFilterUrl(uidParent),
+        checkedFacetUid: uidParent,
+        childrenIds: childrenUids,
+        parentFacetUid: undefined,
+      }
+      this.historyData[uidParent] = parentClickParams
+    })
+  }
+
+  // NOTE: used to be called handleClick
+  setSelected = ({ href, checkedFacetUid, childrenIds, parentFacetUid }) => {
+    const { lastCheckedUid, lastCheckedChildrenUids, lastCheckedParentFacetUid } = this.state
+
+    let unselected = undefined
+
+    // 'uncheck' previous
+    if (lastCheckedUid) {
+      unselected = {
+        checkedFacetUid: lastCheckedUid,
+        childrenIds: lastCheckedChildrenUids,
+        parentFacetUid: lastCheckedParentFacetUid,
+      }
+    }
+
+    // 'check' new
+    this.setState(
+      {
+        lastCheckedUid: checkedFacetUid,
+        lastCheckedChildrenUids: childrenIds,
+        lastCheckedParentFacetUid: parentFacetUid,
+      },
+      () => {
+        const selected = {
+          checkedFacetUid,
+          childrenIds,
+        }
+        this.props.setDialectFilter({
+          facetField: this.state.facetField,
+          selected,
+          unselected,
+          href,
+        })
+      }
+    )
+  }
+
+  handleHistoryEvent = () => {
+    const _filterId =
+      this.props.type === 'words'
+        ? selectn('routeParams.category', this.props)
+        : selectn('routeParams.phraseBook', this.props)
+    if (_filterId) {
+      const selectedParams = this.historyData[_filterId]
+      if (selectedParams) {
+        const { href, checkedFacetUid, childrenIds, parentFacetUid } = selectedParams
+        this.setState(
+          {
+            lastCheckedUid: checkedFacetUid,
+            lastCheckedChildrenUids: childrenIds,
+            lastCheckedParentFacetUid: parentFacetUid,
+          },
+          () => {
+            const selected = {
+              checkedFacetUid,
+              childrenIds,
+            }
+            this.props.setDialectFilter({
+              facetField: this.state.facetField,
+              selected,
+              href,
+              updateUrl: false,
+            })
+          }
+        )
+      }
+    }
+  }
+
+  setUidUrlPath = (filter, path) => {
+    // TODO: map encodeUri title to uid for friendly urls
+    // this.uidUrl[category.uid] = encodeURI(category.title)
+
+    // TODO: temp using uid in url
+    this.uidUrl[filter.uid] = `${path}/${encodeURI(filter.uid)}`
+  }
+
+  sortByTitle = (a, b) => {
+    if (a.title < b.title) return -1
+    if (a.title > b.title) return 1
+    return 0
+  }
+
+  sortDialectFilters = (filters = []) => {
+    const _filters = [...filters]
+    // Sort root level
+    _filters.sort(this.sortByTitle)
+    const _filtersSorted = _filters.map((filter) => {
+      // Sort children
+      const children = selectn('contextParameters.children.entries', filter)
+      if (children.length > 0) {
+        children.sort(this.sortByTitle)
+      }
+      return filter
+    })
+    return _filtersSorted
+  }
+}
+
+// PROPTYPES
+const { any, array, func, instanceOf, object, string } = PropTypes
+DialectFilterListData.propTypes = {
+  appliedFilterIds: instanceOf(Set),
+  children: any,
+  dialectFilterListWillUnmount: func,
+  path: string.isRequired, // Used with facets
+  setDialectFilter: func,
+  type: string.isRequired,
+  workspaceKey: string.isRequired, // Used with facetField
+  // REDUX: reducers/state
+  computeCategories: object.isRequired,
+  routeParams: object.isRequired,
+  splitWindowPath: array.isRequired,
+  // REDUX: actions/dispatch/func
+  fetchCategories: func.isRequired,
+}
+DialectFilterListData.defaultProps = {
+  dialectFilterListWillUnmount: () => {},
+  setDialectFilter: () => {},
+}
+
+// REDUX: reducers/state
+const mapStateToProps = (state) => {
+  const { fvCategory, navigation, windowPath } = state
+  const { computeCategories } = fvCategory
+  const { route } = navigation
+  const { splitWindowPath } = windowPath
+  return {
+    computeCategories,
+    routeParams: route.routeParams,
+    splitWindowPath,
+  }
+}
+// REDUX: actions/dispatch/func
+const mapDispatchToProps = {
+  fetchCategories,
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(DialectFilterListData)

--- a/frontend/app/assets/javascripts/views/components/DialectFilterList/DialectFilterListPresentation.js
+++ b/frontend/app/assets/javascripts/views/components/DialectFilterList/DialectFilterListPresentation.js
@@ -8,33 +8,9 @@ import selectn from 'selectn'
 import { connect } from 'react-redux'
 import { pushWindowPath } from 'providers/redux/reducers/windowPath'
 import Link from 'views/components/Link'
-import URLHelpers from '../../../common/URLHelpers'
+import URLHelpers from 'common/URLHelpers'
 
-const { instanceOf, any, array, func, object, string } = PropTypes
-
-export class DialectFilterList extends Component {
-  static propTypes = {
-    appliedFilterIds: instanceOf(Set),
-    facetField: string.isRequired,
-    facets: array.isRequired,
-    handleDialectFilterClick: func,
-    handleDialectFilterList: func.isRequired,
-    routeParams: any,
-    styles: object,
-    title: string.isRequired,
-    type: string.isRequired,
-    // REDUX: reducers/state
-    splitWindowPath: array,
-    // REDUX: actions/dispatch/func
-    pushWindowPath: func.isRequired,
-  }
-
-  static defaultProps = {
-    type: 'words',
-    facets: [],
-    handleDialectFilterClick: () => {},
-  }
-
+export class DialectFilterListPresentation extends Component {
   clickParams = {}
   filtersSorted = []
   _isMounted = false
@@ -384,6 +360,30 @@ export class DialectFilterList extends Component {
   }
 }
 
+// PropTypes
+const { instanceOf, any, array, func, object, string } = PropTypes
+DialectFilterListPresentation.propTypes = {
+  appliedFilterIds: instanceOf(Set),
+  facetField: string.isRequired,
+  facets: array.isRequired,
+  handleDialectFilterClick: func,
+  handleDialectFilterList: func.isRequired,
+  routeParams: any,
+  styles: object,
+  title: string.isRequired,
+  type: string.isRequired,
+  // REDUX: reducers/state
+  splitWindowPath: array,
+  // REDUX: actions/dispatch/func
+  pushWindowPath: func.isRequired,
+}
+
+DialectFilterListPresentation.defaultProps = {
+  type: 'words',
+  facets: [],
+  handleDialectFilterClick: () => {},
+}
+
 // REDUX: reducers/state
 const mapStateToProps = (state /*, ownProps*/) => {
   const { windowPath } = state
@@ -400,4 +400,4 @@ const mapDispatchToProps = {
   pushWindowPath,
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(DialectFilterList)
+export default connect(mapStateToProps, mapDispatchToProps)(DialectFilterListPresentation)

--- a/frontend/app/assets/javascripts/views/components/DialectFilterList/DialectFilterListPresentation.js
+++ b/frontend/app/assets/javascripts/views/components/DialectFilterList/DialectFilterListPresentation.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import Link from 'views/components/Link'
+import '!style-loader!css-loader!./DialectFilterList.css'
 
 export class DialectFilterListPresentation extends Component {
   render() {

--- a/frontend/app/assets/javascripts/views/components/DialectFilterList/DialectFilterListPresentation.js
+++ b/frontend/app/assets/javascripts/views/components/DialectFilterList/DialectFilterListPresentation.js
@@ -1,403 +1,91 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-// eslint-disable-next-line
-import Immutable, { Set } from 'immutable'
-import selectn from 'selectn'
-
-// REDUX
-import { connect } from 'react-redux'
-import { pushWindowPath } from 'providers/redux/reducers/windowPath'
 import Link from 'views/components/Link'
-import URLHelpers from 'common/URLHelpers'
 
 export class DialectFilterListPresentation extends Component {
-  clickParams = {}
-  filtersSorted = []
-  _isMounted = false
-  selectedDialectFilter = undefined
-  title = ''
-  uidUrl = {}
-
-  constructor(props, context) {
-    super(props, context)
-
-    this.state = {
-      disableAll: false,
-      lastCheckedUid: undefined,
-      lastCheckedChildrenUids: [],
-      lastCheckedParentFacetUid: undefined,
-      listItems: undefined,
-    }
-
-    this.title = props.title
-  }
-
-  componentDidMount() {
-    this._isMounted = true
-    window.addEventListener('popstate', this.handleHistoryEvent)
-
-    const selectedDialectFilter =
-      this.props.type === 'words'
-        ? selectn('routeParams.category', this.props)
-        : selectn('routeParams.phraseBook', this.props)
-    if (selectedDialectFilter) {
-      this.selectedDialectFilter = selectedDialectFilter
-    }
-
-    if (this.props.facets && this.props.facets.length > 0) {
-      this.filtersSorted = this.sortDialectFilters(this.props.facets)
-      this.generateUidUrlPaths(this.filtersSorted)
-      this.generateListItems(this.filtersSorted, true)
-    }
-  }
-
-  componentWillUnmount() {
-    this._isMounted = false
-    window.removeEventListener('popstate', this.handleHistoryEvent)
-    const { lastCheckedUid, lastCheckedChildrenUids, lastCheckedParentFacetUid } = this.state
-    // 'uncheck' previous
-    if (lastCheckedUid) {
-      const unselected = {
-        checkedFacetUid: lastCheckedUid,
-        childrenIds: lastCheckedChildrenUids,
-        parentFacetUid: lastCheckedParentFacetUid,
-      }
-      this.props.handleDialectFilterList(this.props.facetField, undefined, unselected, this.props.type, false)
-    }
-  }
-
-  componentDidUpdate(prevProps) {
-    const prevAppliedFilterIds = prevProps.appliedFilterIds
-    const currentAppliedFilterIds = this.props.appliedFilterIds
-
-    if (prevProps.facets.length !== this.props.facets.length) {
-      this.filtersSorted = this.sortDialectFilters(this.props.facets)
-      this.generateUidUrlPaths(this.filtersSorted)
-    }
-
-    if (
-      prevProps.facets.length !== this.props.facets.length ||
-      prevAppliedFilterIds.equals(currentAppliedFilterIds) === false
-    ) {
-      this.generateListItems(this.filtersSorted, true)
-    }
-
-    if (prevProps.title !== this.props.title) {
-      this.title = this.props.title
-    }
-  }
-
   render() {
+    const { title, listItemData } = this.props
     return (
       <div className="DialectFilterList" data-testid="DialectFilterList">
-        <h2>{this.title}</h2>
-        <ul className="DialectFilterListList DialectFilterListList--root">{this.state.listItems}</ul>
+        <h2>{title}</h2>
+        {listItemData.length === 0 && this.componentHasNoData()}
+        {listItemData.length !== 0 && this.componentHasData()}
       </div>
     )
   }
 
-  generateUidUrlPaths = (filters) => {
-    const _splitWindowPath = [...this.props.splitWindowPath]
-    const lastPath = _splitWindowPath.pop()
-
-    if (lastPath === 'words' || lastPath === 'phrases') {
-      _splitWindowPath.push(lastPath)
-      const urlFragment = this.props.type === 'words' ? 'categories' : 'book'
-      _splitWindowPath.push(urlFragment)
-    }
-    const path = ('/' + _splitWindowPath.join('/')).replace(URLHelpers.getContextPath(), '')
-
-    filters.forEach((filter) => {
-      this.setUidUrlPath(filter, path)
-      const children = selectn('contextParameters.children.entries', filter)
-      if (children.length > 0) {
-        children.forEach((filterChild) => {
-          this.setUidUrlPath(filterChild, path)
-        })
-      }
-    })
-    return this.uidUrl
-  }
-
-  handleHistoryEvent = () => {
-    if (this._isMounted) {
-      const _filterId =
-        this.props.type === 'words'
-          ? selectn('routeParams.category', this.props)
-          : selectn('routeParams.phraseBook', this.props)
-      // const _catId = selectn('category', this.props.routeParams)
-      if (_filterId) {
-        const selectedParams = this.clickParams[_filterId]
-        if (selectedParams) {
-          const { href, checkedFacetUid, childrenIds, parentFacetUid } = selectedParams
-          // this.handleClick(selectedParams)
-          this.setState(
-            {
-              lastCheckedUid: checkedFacetUid,
-              lastCheckedChildrenUids: childrenIds,
-              lastCheckedParentFacetUid: parentFacetUid,
-            },
-            () => {
-              const selected = {
-                checkedFacetUid,
-                childrenIds,
-              }
-              this.props.handleDialectFilterClick(
-                {
-                  facetField: this.props.facetField,
-                  selected,
-                  undefined,
-                  href,
-                },
-                false
-              )
-            }
-          )
-        }
-      }
-    }
-  }
-
-  setUidUrlPath = (filter, path) => {
-    // TODO: map encodeUri title to uid for friendly urls
-    // this.uidUrl[category.uid] = encodeURI(category.title)
-
-    // TODO: temp using uid in url
-    this.uidUrl[filter.uid] = `${path}/${encodeURI(filter.uid)}`
-  }
-
-  generateDialectFilterUrl = (filterId) => {
-    let href = `/${this.props.splitWindowPath.join('/')}`
-    const _splitWindowPath = [...this.props.splitWindowPath]
-    const wordOrPhraseIndex = _splitWindowPath.findIndex((element) => {
-      return element === 'words' || element === 'phrases'
-    })
-    if (wordOrPhraseIndex !== -1) {
-      _splitWindowPath.splice(wordOrPhraseIndex + 1)
-      const urlFragment = this.props.type === 'words' ? 'categories' : 'book'
-      href = `/${_splitWindowPath.join('/')}/${urlFragment}/${filterId}`
-    }
-    return href
-  }
-
-  generateListItems = (filters, updateState = false) => {
-    const { appliedFilterIds } = this.props
-
-    let lastCheckedUid = undefined
-    let lastCheckedChildrenUids = undefined
-    let lastCheckedParentFacetUid = undefined
-
-    const _filters = filters.map((filter) => {
-      const childrenItems = []
-      const childrenUids = []
-      const uidParent = filter.uid
-
-      const parentIsActive = appliedFilterIds.includes(uidParent)
+  componentHasData = () => {
+    const { listItemData } = this.props
+    const listItems = listItemData.map((parent) => {
+      const {
+        isActive: parentIsActive,
+        hasActiveChild: parentHasActiveChild,
+        uid: parentUid,
+        text: parentText,
+        href: parentHref,
+      } = parent
       const parentActiveClass = parentIsActive ? 'DialectFilterListLink--active' : ''
 
-      const children = selectn('contextParameters.children.entries', filter)
-      let hasActiveChild = false
-      if (children.length > 0) {
-        children.forEach((filterChild) => {
-          if (filterChild.isTrashed) return
-          const uidChild = filterChild.uid
-          childrenUids.push(uidChild)
-          const childIsActive = appliedFilterIds.includes(uidChild)
+      const childrenNodes =
+        parent.children.length > 0
+          ? parent.children.map((child) => {
+              const { isActive: childIsActive, uid: childUid, text: childText, href: childHref } = child
 
-          let childActiveClass = ''
-          if (parentActiveClass) {
-            childActiveClass = 'DialectFilterListLink--activeParent'
-          } else if (childIsActive) {
-            childActiveClass = 'DialectFilterListLink--active'
-          }
+              let childActiveClass = ''
+              if (parentActiveClass) {
+                childActiveClass = 'DialectFilterListLink--activeParent'
+              }
+              if (childIsActive) {
+                childActiveClass = 'DialectFilterListLink--active'
+              }
+              return (
+                <li key={childUid}>
+                  <Link
+                    className={`DialectFilterListLink DialectFilterListLink--child ${childActiveClass}`}
+                    href={childHref}
+                    title={childText}
+                  >
+                    {childText}
+                  </Link>
+                </li>
+              )
+            })
+          : null
 
-          if (childIsActive) {
-            hasActiveChild = true
-            lastCheckedUid = uidChild
-            lastCheckedChildrenUids = null
-            lastCheckedParentFacetUid = uidParent
-          }
-
-          // const childHref = `/${this.uidUrl[uidChild]}`
-          const childHref = this.generateDialectFilterUrl(uidChild)
-          const childClickParams = {
-            href: childHref,
-            checkedFacetUid: uidChild,
-            childrenIds: null,
-            parentFacetUid: uidParent,
-          }
-          // Saving for direct page load events
-          this.clickParams[uidChild] = childClickParams
-          const childListItem = (
-            <li key={uidChild}>
-              <Link
-                className={`DialectFilterListLink DialectFilterListLink--child ${childActiveClass}`}
-                href={childHref}
-                title={filterChild.title}
-              >
-                {filterChild.title}
-              </Link>
-            </li>
-          )
-          childrenItems.push(childListItem)
-        })
-      }
-
-      // const parentHref = `/${this.uidUrl[uidParent]}`
-      const parentHref = this.generateDialectFilterUrl(uidParent)
-
-      if (parentIsActive) {
-        lastCheckedUid = uidParent
-        lastCheckedChildrenUids = childrenUids
-        lastCheckedParentFacetUid = undefined
-      }
-      const listItemActiveClass = parentIsActive || hasActiveChild ? 'DialectFilterListItemParent--active' : ''
-      const parentClickParams = {
-        href: parentHref,
-        checkedFacetUid: uidParent,
-        childrenIds: childrenUids,
-        parentFacetUid: undefined,
-      }
-      // Saving for direct page load events
-      this.clickParams[uidParent] = parentClickParams
-      const parentListItem = (
-        <li key={uidParent} className={`DialectFilterListItemParent ${listItemActiveClass}`}>
+      const parentActiveChildClass = parentHasActiveChild ? 'DialectFilterListLink--activeChild' : ''
+      return (
+        <li key={parentUid} className={`DialectFilterListItemParent ${parentActiveClass} ${parentActiveChildClass}`}>
           <div className="DialectFilterListItemGroup">
             <Link
               className={`DialectFilterListLink DialectFilterListLink--parent ${parentActiveClass}`}
               href={parentHref}
-              title={filter.title}
+              title={parentText}
             >
-              {filter.title}
+              {parentText}
             </Link>
           </div>
-          {childrenItems.length > 0 ? <ul className="DialectFilterListList">{childrenItems}</ul> : null}
+          {childrenNodes && <ul className="DialectFilterListList">{childrenNodes}</ul>}
         </li>
       )
-
-      return parentListItem
     })
 
-    if (updateState) {
-      // Save active item/data
-      this.setState(
-        {
-          listItems: _filters,
-          lastCheckedUid,
-          lastCheckedChildrenUids,
-          lastCheckedParentFacetUid,
-        },
-        () => {
-          if (this.selectedDialectFilter) {
-            const selectedParams = this.clickParams[this.selectedDialectFilter]
-            if (selectedParams) {
-              this.handleClick(selectedParams)
-              this.selectedDialectFilter = undefined
-            }
-          }
-        }
-      )
-    }
+    return listItems ? <ul className="DialectFilterListList DialectFilterListList--root">{listItems}</ul> : null
   }
 
-  handleClick = (obj) => {
-    const { href, checkedFacetUid, childrenIds, parentFacetUid } = obj
-
-    const { lastCheckedUid, lastCheckedChildrenUids, lastCheckedParentFacetUid } = this.state
-
-    let unselected = undefined
-
-    // 'uncheck' previous
-    if (lastCheckedUid) {
-      unselected = {
-        checkedFacetUid: lastCheckedUid,
-        childrenIds: lastCheckedChildrenUids,
-        parentFacetUid: lastCheckedParentFacetUid,
-      }
-    }
-
-    // 'check' new
-    this.setState(
-      {
-        lastCheckedUid: checkedFacetUid,
-        lastCheckedChildrenUids: childrenIds,
-        lastCheckedParentFacetUid: parentFacetUid,
-      },
-      () => {
-        const selected = {
-          checkedFacetUid,
-          childrenIds,
-        }
-        this.props.handleDialectFilterClick({
-          facetField: this.props.facetField,
-          selected,
-          unselected,
-          href,
-        })
-      }
-    )
-  }
-
-  sortByTitle = (a, b) => {
-    if (a.title < b.title) return -1
-    if (a.title > b.title) return 1
-    return 0
-  }
-
-  sortDialectFilters = (filters) => {
-    const _filters = [...filters]
-    // Sort root level
-    _filters.sort(this.sortByTitle)
-    const _filtersSorted = _filters.map((filter) => {
-      // Sort children
-      const children = selectn('contextParameters.children.entries', filter)
-      if (children.length > 0) {
-        children.sort(this.sortByTitle)
-      }
-      return filter
-    })
-    return _filtersSorted
+  componentHasNoData = () => {
+    return null
   }
 }
 
-// PropTypes
-const { instanceOf, any, array, func, object, string } = PropTypes
+// Proptypes
+const { array, string } = PropTypes
 DialectFilterListPresentation.propTypes = {
-  appliedFilterIds: instanceOf(Set),
-  facetField: string.isRequired,
-  facets: array.isRequired,
-  handleDialectFilterClick: func,
-  handleDialectFilterList: func.isRequired,
-  routeParams: any,
-  styles: object,
   title: string.isRequired,
-  type: string.isRequired,
-  // REDUX: reducers/state
-  splitWindowPath: array,
-  // REDUX: actions/dispatch/func
-  pushWindowPath: func.isRequired,
+  listItemData: array,
 }
 
 DialectFilterListPresentation.defaultProps = {
-  type: 'words',
-  facets: [],
-  handleDialectFilterClick: () => {},
+  listItemData: [],
 }
 
-// REDUX: reducers/state
-const mapStateToProps = (state /*, ownProps*/) => {
-  const { windowPath } = state
-
-  const { splitWindowPath } = windowPath
-
-  return {
-    splitWindowPath,
-  }
-}
-
-// REDUX: actions/dispatch/func
-const mapDispatchToProps = {
-  pushWindowPath,
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(DialectFilterListPresentation)
+export default DialectFilterListPresentation

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/index.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/index.js
@@ -21,7 +21,6 @@ import classNames from 'classnames'
 // REDUX
 import { connect } from 'react-redux'
 // REDUX: actions/dispatch/func
-import { fetchCategories } from 'providers/redux/reducers/fvCategory'
 import { fetchCharacters } from 'providers/redux/reducers/fvCharacter'
 import { fetchDocument } from 'providers/redux/reducers/document'
 import { fetchPortal } from 'providers/redux/reducers/fvPortal'
@@ -41,6 +40,8 @@ import PageDialectLearnBase from 'views/pages/explore/dialect/learn/base'
 import PhraseListView from 'views/pages/explore/dialect/learn/phrases/list-view'
 
 import DialectFilterListPresentation from 'views/components/DialectFilterList/DialectFilterListPresentation'
+import DialectFilterListData from 'views/components/DialectFilterList/DialectFilterListData'
+
 import AlphabetListView from 'views/components/AlphabetListView'
 import FVLabel from 'views/components/FVLabel/index'
 
@@ -62,7 +63,6 @@ export class PageDialectLearnPhrases extends PageDialectLearnBase {
     hasPagination: bool,
     routeParams: object.isRequired,
     // REDUX: reducers/state
-    computeCategories: object.isRequired,
     computeDocument: object.isRequired,
     computeLogin: object.isRequired,
     computePortal: object.isRequired,
@@ -70,7 +70,6 @@ export class PageDialectLearnPhrases extends PageDialectLearnBase {
     splitWindowPath: array.isRequired,
     windowPath: string.isRequired,
     // REDUX: actions/dispatch/func
-    fetchCategories: func.isRequired,
     fetchDocument: func.isRequired,
     fetchPortal: func.isRequired,
     overrideBreadcrumbs: func.isRequired,
@@ -81,33 +80,22 @@ export class PageDialectLearnPhrases extends PageDialectLearnBase {
     searchDialectUpdate: () => {},
   }
 
-  DIALECT_FILTER_TYPE = 'phrases'
-
   async componentDidMountViaPageDialectLearnBase() {
     const { routeParams } = this.props
 
     // Portal
-    ProviderHelpers.fetchIfMissing(
+    await ProviderHelpers.fetchIfMissing(
       this.props.routeParams.dialect_path + '/Portal',
       this.props.fetchPortal,
       this.props.computePortal
     )
 
     // Document
-    ProviderHelpers.fetchIfMissing(
+    await ProviderHelpers.fetchIfMissing(
       this.props.routeParams.dialect_path + '/Dictionary',
       this.props.fetchDocument,
       this.props.computeDocument
     )
-
-    // Phrasebooks (Category)
-    let phraseBooks = this.getPhraseBooks()
-    if (phraseBooks === undefined) {
-      await this.props.fetchCategories(
-        '/api/v1/path/' + this.props.routeParams.dialect_path + '/Phrase Books/@children'
-      )
-      phraseBooks = this.getPhraseBooks()
-    }
 
     // Alphabet
     // ---------------------------------------------
@@ -125,7 +113,10 @@ export class PageDialectLearnPhrases extends PageDialectLearnBase {
 
     const newState = {
       characters,
-      phraseBooks,
+      dialectId: selectn(
+        'response.contextParameters.ancestry.dialect.uid',
+        ProviderHelpers.getEntry(this.props.computeDocument, routeParams.dialect_path + '/Dictionary')
+      ),
     }
 
     // Clear out filterInfo if not in url, eg: /learn/words/categories/[category]
@@ -167,10 +158,6 @@ export class PageDialectLearnPhrases extends PageDialectLearnBase {
         id: this.props.routeParams.dialect_path + '/Dictionary',
         entity: this.props.computeDocument,
       },
-      {
-        id: '/api/v1/path/' + this.props.routeParams.dialect_path + '/Phrase Books/@children',
-        entity: this.props.computeCategories,
-      },
     ])
 
     this.state = {
@@ -203,14 +190,9 @@ export class PageDialectLearnPhrases extends PageDialectLearnBase {
       this.props.computePortal,
       this.props.routeParams.dialect_path + '/Portal'
     )
-    const computePhraseBooks = ProviderHelpers.getEntry(
-      this.props.computeCategories,
-      '/api/v1/path/' + this.props.routeParams.dialect_path + '/Phrase Books/@children'
-    )
 
     const { searchByMode } = this.props.computeSearchDialect
 
-    const computePhraseBooksSize = selectn('response.entries.length', computePhraseBooks) || 0
     const dialect = selectn('response.contextParameters.ancestry.dialect.dc:title', computePortal) || ''
     const pageTitle = this.props.intl.trans(
       'views.pages.explore.dialect.phrases.x_phrases',
@@ -219,12 +201,8 @@ export class PageDialectLearnPhrases extends PageDialectLearnBase {
       [dialect]
     )
     const { DEFAULT_PAGE, DEFAULT_PAGE_SIZE } = this._getURLPageProps() // NOTE: This function is in PageDialectLearnBase
-    const dialectId = selectn(
-      'response.contextParameters.ancestry.dialect.uid',
-      ProviderHelpers.getEntry(this.props.computeDocument, this.props.routeParams.dialect_path + '/Dictionary')
-    )
     const phraseListView =
-      selectn('response.uid', computeDocument) && dialectId ? (
+      selectn('response.uid', computeDocument) && this.state.dialectId ? (
         <PhraseListView
           controlViaURL
           DEFAULT_PAGE_SIZE={DEFAULT_PAGE_SIZE}
@@ -235,7 +213,7 @@ export class PageDialectLearnPhrases extends PageDialectLearnBase {
           flashcardTitle={pageTitle}
           onPagePropertiesChange={this._handlePagePropertiesChange} // NOTE: This function is in PageDialectLearnBase
           parentID={selectn('response.uid', computeDocument)}
-          dialectID={dialectId}
+          dialectID={this.state.dialectId}
           routeParams={this.props.routeParams}
           // Search:
           handleSearch={this.handleSearch}
@@ -335,26 +313,31 @@ export class PageDialectLearnPhrases extends PageDialectLearnBase {
               handleClick={this.handleAlphabetClick}
               letter={selectn('routeParams.letter', this.props)}
             />
-            {computePhraseBooksSize !== 0 && (
-              <DialectFilterListPresentation
-                appliedFilterIds={this.state.filterInfo.get('currentCategoryFilterIds')}
-                // clearDialectFilter={this.clearDialectFilter} // TODO: NOT IN WORDS
-                facetField={ProviderHelpers.switchWorkspaceSectionKeys(
-                  'fv-phrase:phrase_books',
-                  this.props.routeParams.area
-                )}
-                facets={this.state.phraseBooks} // TODO: NOT IN WORDS
-                handleDialectFilterClick={this.handlePhraseBookClick} // TODO: NOT IN WORDS
-                handleDialectFilterList={this.handleDialectFilterList} // NOTE: This function is in PageDialectLearnBase
-                routeParams={this.props.routeParams}
-                title={this.props.intl.trans(
-                  'views.pages.explore.dialect.learn.phrases.browse_by_phrase_books',
-                  'Browse Phrase Books',
-                  'words'
-                )}
-                type={this.DIALECT_FILTER_TYPE}
-              />
-            )}
+
+            <DialectFilterListData
+              workspaceKey="fv-phrase:phrase_books"
+              path={`/api/v1/path/${this.props.routeParams.dialect_path}/Phrase Books/@children`}
+            >
+              {({ facetField, facets }) => {
+                return (
+                  <DialectFilterListPresentation
+                    appliedFilterIds={this.state.filterInfo.get('currentCategoryFilterIds')}
+                    // clearDialectFilter={this.clearDialectFilter} // TODO: NOT IN WORDS
+                    facetField={facetField}
+                    facets={facets} // TODO: NOT IN WORDS
+                    handleDialectFilterClick={this.handlePhraseBookClick} // TODO: NOT IN WORDS
+                    handleDialectFilterList={this.handleDialectFilterList} // NOTE: This function is in PageDialectLearnBase
+                    routeParams={this.props.routeParams}
+                    title={this.props.intl.trans(
+                      'views.pages.explore.dialect.learn.phrases.browse_by_phrase_books',
+                      'Browse Phrase Books',
+                      'words'
+                    )}
+                    type="phrases"
+                  />
+                )
+              }}
+            </DialectFilterListData>
           </div>
           <div className={classNames('col-xs-12', 'col-md-9')}>
             <h1 className="DialectPageTitle">{pageTitle}</h1>
@@ -424,13 +407,6 @@ export class PageDialectLearnPhrases extends PageDialectLearnBase {
     return selectn('response.entries', computedCharacters)
   }
 
-  getPhraseBooks = () => {
-    const computeCategories = ProviderHelpers.getEntry(
-      this.props.computeCategories,
-      '/api/v1/path/' + this.props.routeParams.dialect_path + '/Phrase Books/@children'
-    )
-    return selectn('response.entries', computeCategories)
-  }
   handleAlphabetClick = async (letter, href, updateHistory = true) => {
     await this.props.searchDialectUpdate({
       searchByAlphabet: letter,
@@ -530,21 +506,9 @@ export class PageDialectLearnPhrases extends PageDialectLearnBase {
 }
 
 // REDUX: reducers/state
-const mapStateToProps = (state /*, ownProps*/) => {
-  const {
-    document,
-    fvCategory,
-    fvPortal,
-    fvCharacter,
-    listView,
-    navigation,
-    nuxeo,
-    searchDialect,
-    windowPath,
-    locale,
-  } = state
+const mapStateToProps = (state) => {
+  const { document, fvPortal, fvCharacter, listView, navigation, nuxeo, searchDialect, windowPath, locale } = state
 
-  const { computeCategories } = fvCategory
   const { computeCharacters } = fvCharacter
   const { computeDocument } = document
   const { computeLogin } = nuxeo
@@ -555,7 +519,6 @@ const mapStateToProps = (state /*, ownProps*/) => {
   const { intlService } = locale
 
   return {
-    computeCategories,
     computeCharacters,
     computeDocument,
     computeLogin,
@@ -571,7 +534,6 @@ const mapStateToProps = (state /*, ownProps*/) => {
 
 // REDUX: actions/dispatch/func
 const mapDispatchToProps = {
-  fetchCategories,
   fetchCharacters,
   fetchDocument,
   fetchPortal,

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/index.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/index.js
@@ -40,7 +40,7 @@ import AuthorizationFilter from 'views/components/Document/AuthorizationFilter'
 import PageDialectLearnBase from 'views/pages/explore/dialect/learn/base'
 import PhraseListView from 'views/pages/explore/dialect/learn/phrases/list-view'
 
-import DialectFilterList from 'views/components/DialectFilterList'
+import DialectFilterListPresentation from 'views/components/DialectFilterList/DialectFilterListPresentation'
 import AlphabetListView from 'views/components/AlphabetListView'
 import FVLabel from 'views/components/FVLabel/index'
 
@@ -336,7 +336,7 @@ export class PageDialectLearnPhrases extends PageDialectLearnBase {
               letter={selectn('routeParams.letter', this.props)}
             />
             {computePhraseBooksSize !== 0 && (
-              <DialectFilterList
+              <DialectFilterListPresentation
                 appliedFilterIds={this.state.filterInfo.get('currentCategoryFilterIds')}
                 // clearDialectFilter={this.clearDialectFilter} // TODO: NOT IN WORDS
                 facetField={ProviderHelpers.switchWorkspaceSectionKeys(

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/index.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/index.js
@@ -315,25 +315,30 @@ export class PageDialectLearnPhrases extends PageDialectLearnBase {
             />
 
             <DialectFilterListData
-              workspaceKey="fv-phrase:phrase_books"
+              appliedFilterIds={this.state.filterInfo.get('currentCategoryFilterIds')}
               path={`/api/v1/path/${this.props.routeParams.dialect_path}/Phrase Books/@children`}
+              type="phrases"
+              workspaceKey="fv-phrase:phrase_books"
+              // ------------------------------------------------
+              // PREVIOUSLY ATTACHED TO PRESENTATION COMPONENT
+              // May not be needed
+              // ------------------------------------------------
+              // // clearDialectFilter={this.clearDialectFilter} // TODO: NOT IN WORDS
+              // facetField={facetField}
+              // facets={facets} // TODO: NOT IN WORDS
+              // handleDialectFilterClick={this.handlePhraseBookClick} // TODO: NOT IN WORDS
+              // handleDialectFilterList={this.handleDialectFilterList} // NOTE: This function is in PageDialectLearnBase
+              // routeParams={this.props.routeParams}
             >
-              {({ facetField, facets }) => {
+              {({ listItemData }) => {
                 return (
                   <DialectFilterListPresentation
-                    appliedFilterIds={this.state.filterInfo.get('currentCategoryFilterIds')}
-                    // clearDialectFilter={this.clearDialectFilter} // TODO: NOT IN WORDS
-                    facetField={facetField}
-                    facets={facets} // TODO: NOT IN WORDS
-                    handleDialectFilterClick={this.handlePhraseBookClick} // TODO: NOT IN WORDS
-                    handleDialectFilterList={this.handleDialectFilterList} // NOTE: This function is in PageDialectLearnBase
-                    routeParams={this.props.routeParams}
                     title={this.props.intl.trans(
                       'views.pages.explore.dialect.learn.phrases.browse_by_phrase_books',
                       'Browse Phrase Books',
                       'words'
                     )}
-                    type="phrases"
+                    listItemData={listItemData}
                   />
                 )
               }}

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/phrasesFilteredByCategory.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/phrasesFilteredByCategory.js
@@ -71,11 +71,7 @@ import {
   updateUrlIfPageOrPageSizeIsDifferent,
   useIdOrPathFallback,
 } from 'views/pages/explore/dialect/learn/base'
-import {
-  SEARCH_BY_ALPHABET,
-  SEARCH_BY_PHRASE_BOOK,
-  SEARCH_PART_OF_SPEECH_ANY,
-} from 'views/components/SearchDialect/constants'
+import { SEARCH_BY_ALPHABET, SEARCH_PART_OF_SPEECH_ANY } from 'views/components/SearchDialect/constants'
 import { WORKSPACES } from 'common/Constants'
 
 const DictionaryList = React.lazy(() => import('views/components/Browsing/DictionaryList'))
@@ -345,42 +341,47 @@ export class PhrasesFilteredByCategory extends Component {
             />
 
             <DialectFilterListData
-              workspaceKey="fv-phrase:phrase_books"
+              appliedFilterIds={new Set([routeParams.phraseBook])}
+              setDialectFilterCallback={this.setDialectFilterCallback} // TODO
               path={`/api/v1/path/${this.props.routeParams.dialect_path}/Phrase Books/@children`}
+              workspaceKey="fv-phrase:phrase_books" // TODO?
+              type={this.DIALECT_FILTER_TYPE}
+              // ------------------------------------------------
+              // PREVIOUSLY ATTACHED TO PRESENTATION COMPONENT
+              // May not be needed
+              // ------------------------------------------------
+              // clearDialectFilter={this.clearDialectFilter}
+              // facets={facets}
+              // facetField={facetField}
+              // handleDialectFilterClick={this.handleCategoryClick}
+              // handleDialectFilterList={(
+              //   facetFieldParam,
+              //   selected,
+              //   unselected,
+              //   type,
+              //   shouldResetUrlPagination
+              // ) => {
+              //   this.handleDialectFilterChange({
+              //     facetField: facetFieldParam,
+              //     selected,
+              //     type,
+              //     unselected,
+              //     routeParams: routeParams,
+              //     filterInfo: filterInfo,
+              //     shouldResetUrlPagination,
+              //   })
+              // }}
+              // routeParams={routeParams}
             >
-              {({ facetField, facets }) => {
+              {({ listItemData }) => {
                 return (
                   <DialectFilterListPresentation
-                    appliedFilterIds={new Set([routeParams.phraseBook])}
-                    clearDialectFilter={this.clearDialectFilter}
-                    facets={facets}
-                    facetField={facetField}
-                    // filterInfo={filterInfo} // TODO ?
-                    handleDialectFilterClick={this.handleCategoryClick}
-                    handleDialectFilterList={(
-                      facetFieldParam,
-                      selected,
-                      unselected,
-                      type,
-                      shouldResetUrlPagination
-                    ) => {
-                      this.handleDialectFilterChange({
-                        facetField: facetFieldParam,
-                        selected,
-                        type,
-                        unselected,
-                        routeParams: routeParams,
-                        filterInfo: filterInfo,
-                        shouldResetUrlPagination,
-                      })
-                    }}
-                    routeParams={routeParams}
                     title={intl.trans(
                       'views.pages.explore.dialect.learn.phrases.browse_by_phrase_books',
                       'Browse Phrase Books',
                       'words'
                     )}
-                    type={this.DIALECT_FILTER_TYPE}
+                    listItemData={listItemData}
                   />
                 )
               }}
@@ -649,20 +650,7 @@ export class PhrasesFilteredByCategory extends Component {
     NavigationHelpers.navigate(href, this.props.pushWindowPath)
   }
 
-  handleCategoryClick = async ({ facetField, selected, unselected } = {}) => {
-    await this.props.searchDialectUpdate({
-      searchByAlphabet: '',
-      searchByMode: SEARCH_BY_PHRASE_BOOK,
-      searchBySettings: {
-        searchByTitle: true,
-        searchByDefinitions: false,
-        searchByTranslations: false,
-        searchPartOfSpeech: SEARCH_PART_OF_SPEECH_ANY,
-      },
-      searchingDialectFilter: selected.checkedFacetUid,
-      searchTerm: '',
-    })
-
+  setDialectFilterCallback = async ({ facetField, selected, unselected } = {}) => {
     this.changeFilter()
 
     this.handleDialectFilterChange({

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/phrasesFilteredByCategory.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/phrasesFilteredByCategory.js
@@ -37,7 +37,7 @@ import { setRouteParams, updatePageProperties } from 'providers/redux/reducers/n
 // -------------------------------------------
 import AlphabetListView from 'views/components/AlphabetListView'
 import AuthorizationFilter from 'views/components/Document/AuthorizationFilter'
-import DialectFilterList from 'views/components/DialectFilterList'
+import DialectFilterListPresentation from 'views/components/DialectFilterList/DialectFilterListPresentation'
 import Edit from '@material-ui/icons/Edit'
 import FVButton from 'views/components/FVButton'
 import IntlService from 'views/services/intl'
@@ -370,7 +370,7 @@ export class PhrasesFilteredByCategory extends Component {
             />
 
             {computedPhraseBooksSize !== 0 && (
-              <DialectFilterList
+              <DialectFilterListPresentation
                 appliedFilterIds={new Set([routeParams.phraseBook])}
                 clearDialectFilter={this.clearDialectFilter}
                 facets={phraseBook}

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/index.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/index.js
@@ -39,7 +39,7 @@ import AuthorizationFilter from 'views/components/Document/AuthorizationFilter'
 import PageDialectLearnBase from 'views/pages/explore/dialect/learn/base'
 import WordListView from 'views/pages/explore/dialect/learn/words/list-view'
 
-import DialectFilterList from 'views/components/DialectFilterList'
+import DialectFilterListPresentation from 'views/components/DialectFilterList/DialectFilterListPresentation'
 import AlphabetListView from 'views/components/AlphabetListView'
 import FVLabel from 'views/components/FVLabel/index'
 
@@ -316,7 +316,7 @@ class PageDialectLearnWords extends PageDialectLearnBase {
             <CategoriesDataLayer fetchLatest>
               {({ categoriesData }) => {
                 return (
-                  <DialectFilterList
+                  <DialectFilterListPresentation
                     appliedFilterIds={filterInfo.get('currentCategoryFilterIds')}
                     facetField={ProviderHelpers.switchWorkspaceSectionKeys(
                       'fv-word:categories',

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/index.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/index.js
@@ -39,7 +39,9 @@ import AuthorizationFilter from 'views/components/Document/AuthorizationFilter'
 import PageDialectLearnBase from 'views/pages/explore/dialect/learn/base'
 import WordListView from 'views/pages/explore/dialect/learn/words/list-view'
 
+import DialectFilterListData from 'views/components/DialectFilterList/DialectFilterListData'
 import DialectFilterListPresentation from 'views/components/DialectFilterList/DialectFilterListPresentation'
+
 import AlphabetListView from 'views/components/AlphabetListView'
 import FVLabel from 'views/components/FVLabel/index'
 
@@ -58,27 +60,6 @@ const { array, bool, func, object, string } = PropTypes
  * Learn words
  */
 class PageDialectLearnWords extends PageDialectLearnBase {
-  static propTypes = {
-    hasPagination: bool,
-    routeParams: object.isRequired,
-    // REDUX: reducers/state
-    computeDocument: object.isRequired,
-    computeLogin: object.isRequired,
-    computePortal: object.isRequired,
-    properties: object.isRequired,
-    splitWindowPath: array.isRequired,
-    windowPath: string.isRequired,
-    // REDUX: actions/dispatch/func
-    fetchDocument: func.isRequired,
-    fetchPortal: func.isRequired,
-    overrideBreadcrumbs: func.isRequired,
-    pushWindowPath: func.isRequired,
-    replaceWindowPath: func.isRequired,
-    searchDialectUpdate: func,
-  }
-  static defaultProps = {
-    searchDialectUpdate: () => {},
-  }
   async componentDidMountViaPageDialectLearnBase() {
     const { routeParams } = this.props
 
@@ -316,22 +297,34 @@ class PageDialectLearnWords extends PageDialectLearnBase {
             <CategoriesDataLayer fetchLatest>
               {({ categoriesData }) => {
                 return (
-                  <DialectFilterListPresentation
-                    appliedFilterIds={filterInfo.get('currentCategoryFilterIds')}
-                    facetField={ProviderHelpers.switchWorkspaceSectionKeys(
-                      'fv-word:categories',
-                      this.props.routeParams.area
-                    )}
-                    facets={categoriesData}
-                    handleDialectFilterList={this.handleDialectFilterList} // NOTE: This function is in PageDialectLearnBase
-                    routeParams={this.props.routeParams}
-                    title={this.props.intl.trans(
-                      'views.pages.explore.dialect.learn.words.browse_by_category',
-                      'Browse Categories',
-                      'words'
-                    )}
-                    type={this.DIALECT_FILTER_TYPE}
-                  />
+                  categoriesData &&
+                  categoriesData.length > 0 && (
+                    <DialectFilterListData
+                      appliedFilterIds={filterInfo.get('currentCategoryFilterIds')}
+                      setDialectFilterCallback={this.setDialectFilterCallback}
+                      transformData={categoriesData}
+                      type="words"
+                      // --------
+                      // facetField={ProviderHelpers.switchWorkspaceSectionKeys(
+                      //   'fv-word:categories',
+                      //   this.props.routeParams.area
+                      // )}
+                      // handleDialectFilterList={this.handleDialectFilterList} // NOTE: This function is in PageDialectLearnBase
+                    >
+                      {({ listItemData }) => {
+                        return (
+                          <DialectFilterListPresentation
+                            title={this.props.intl.trans(
+                              'views.pages.explore.dialect.learn.words.browse_by_category',
+                              'Browse Categories',
+                              'words'
+                            )}
+                            listItemData={listItemData}
+                          />
+                        )
+                      }}
+                    </DialectFilterListData>
+                  )
                 )
               }}
             </CategoriesDataLayer>
@@ -490,6 +483,39 @@ class PageDialectLearnWords extends PageDialectLearnBase {
       }
     )
   }
+
+  setDialectFilterCallback = ({
+    // facetField,
+    href,
+    // selected,
+    // unselected,
+    updateUrl,
+  }) => {
+    this.changeFilter({ href, updateHistory: updateUrl })
+  }
+}
+
+// Proptypes
+PageDialectLearnWords.propTypes = {
+  hasPagination: bool,
+  routeParams: object.isRequired,
+  // REDUX: reducers/state
+  computeDocument: object.isRequired,
+  computeLogin: object.isRequired,
+  computePortal: object.isRequired,
+  properties: object.isRequired,
+  splitWindowPath: array.isRequired,
+  windowPath: string.isRequired,
+  // REDUX: actions/dispatch/func
+  fetchDocument: func.isRequired,
+  fetchPortal: func.isRequired,
+  overrideBreadcrumbs: func.isRequired,
+  pushWindowPath: func.isRequired,
+  replaceWindowPath: func.isRequired,
+  searchDialectUpdate: func,
+}
+PageDialectLearnWords.defaultProps = {
+  searchDialectUpdate: () => {},
 }
 
 // REDUX: reducers/state

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/wordsFilteredByCategory.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/wordsFilteredByCategory.js
@@ -35,7 +35,10 @@ import { setRouteParams, updatePageProperties } from 'providers/redux/reducers/n
 // -------------------------------------------
 import AlphabetListView from 'views/components/AlphabetListView'
 import AuthorizationFilter from 'views/components/Document/AuthorizationFilter'
+
+import DialectFilterListData from 'views/components/DialectFilterList/DialectFilterListData'
 import DialectFilterListPresentation from 'views/components/DialectFilterList/DialectFilterListPresentation'
+
 import Edit from '@material-ui/icons/Edit'
 import FVButton from 'views/components/FVButton'
 import IntlService from 'views/services/intl'
@@ -55,7 +58,6 @@ import {
 } from 'views/components/Browsing/DictionaryListSmallScreen'
 import {
   getCharacters,
-  handleDialectFilterList,
   onNavigateRequest,
   sortHandler,
   updateFilter,
@@ -63,11 +65,7 @@ import {
   updateUrlIfPageOrPageSizeIsDifferent,
   useIdOrPathFallback,
 } from 'views/pages/explore/dialect/learn/base'
-import {
-  SEARCH_BY_ALPHABET,
-  SEARCH_BY_CATEGORY,
-  SEARCH_PART_OF_SPEECH_ANY,
-} from 'views/components/SearchDialect/constants'
+import { SEARCH_BY_ALPHABET, SEARCH_PART_OF_SPEECH_ANY } from 'views/components/SearchDialect/constants'
 import { WORKSPACES } from 'common/Constants'
 import CategoriesDataLayer from 'views/pages/explore/dialect/learn/words/categoriesDataLayer'
 const DictionaryList = React.lazy(() => import('views/components/Browsing/DictionaryList'))
@@ -78,7 +76,6 @@ const intl = IntlService.instance
 class WordsFilteredByCategory extends Component {
   DEFAULT_SORT_COL = 'fv:custom_order' // NOTE: Used when paging
   DEFAULT_SORT_TYPE = 'asc'
-  DIALECT_FILTER_TYPE = 'words'
 
   componentDidUpdate(prevProps) {
     const { routeParams: curRouteParams } = this.props
@@ -292,7 +289,7 @@ class WordsFilteredByCategory extends Component {
     }
 
     const dialectClassName = getDialectClassname(computedPortal)
-    const facetField = ProviderHelpers.switchWorkspaceSectionKeys('fv-word:categories', routeParams.area)
+    // const facetField = ProviderHelpers.switchWorkspaceSectionKeys('fv-word:categories', routeParams.area)
     return (
       <PromiseWrapper renderOnError computeEntities={computeEntities}>
         <div className="row row-create-wrapper">
@@ -343,39 +340,29 @@ class WordsFilteredByCategory extends Component {
             <CategoriesDataLayer>
               {({ categoriesData }) => {
                 return (
-                  <DialectFilterListPresentation
-                    appliedFilterIds={new Set([routeParams.category])}
-                    clearDialectFilter={this.clearDialectFilter}
-                    facets={categoriesData}
-                    // facets={categories}
-                    facetField={facetField}
-                    filterInfo={filterInfo}
-                    handleDialectFilterClick={this.handleCategoryClick}
-                    handleDialectFilterList={(
-                      facetFieldParam,
-                      selected,
-                      unselected,
-                      type,
-                      shouldResetUrlPagination
-                    ) => {
-                      this.handleDialectFilterChange({
-                        facetField: facetFieldParam,
-                        selected,
-                        type,
-                        unselected,
-                        routeParams: routeParams,
-                        filterInfo: filterInfo,
-                        shouldResetUrlPagination,
-                      })
-                    }}
-                    routeParams={routeParams}
-                    title={intl.trans(
-                      'views.pages.explore.dialect.learn.words.browse_by_category',
-                      'Browse Categories',
-                      'words'
-                    )}
-                    type={this.DIALECT_FILTER_TYPE}
-                  />
+                  categoriesData &&
+                  categoriesData.length > 0 && (
+                    <DialectFilterListData
+                      appliedFilterIds={new Set([routeParams.category])}
+                      setDialectFilterCallback={this.setDialectFilterCallback}
+                      transformData={categoriesData}
+                      type="words"
+                      // workspaceKey="fv-phrase:phrase_books" // TODO?
+                    >
+                      {({ listItemData }) => {
+                        return (
+                          <DialectFilterListPresentation
+                            title={intl.trans(
+                              'views.pages.explore.dialect.learn.words.browse_by_category',
+                              'Browse Categories',
+                              'words'
+                            )}
+                            listItemData={listItemData}
+                          />
+                        )
+                      }}
+                    </DialectFilterListData>
+                  )
                 )
               }}
             </CategoriesDataLayer>
@@ -633,58 +620,6 @@ class WordsFilteredByCategory extends Component {
     NavigationHelpers.navigate(href, this.props.pushWindowPath)
   }
 
-  handleCategoryClick = async ({ facetField, selected, unselected }) => {
-    await this.props.searchDialectUpdate({
-      searchByAlphabet: '',
-      searchByMode: SEARCH_BY_CATEGORY,
-      searchBySettings: {
-        searchByTitle: true,
-        searchByDefinitions: false,
-        searchByTranslations: false,
-        searchPartOfSpeech: SEARCH_PART_OF_SPEECH_ANY,
-      },
-      searchingDialectFilter: selected.checkedFacetUid,
-      searchTerm: '',
-    })
-
-    this.changeFilter()
-
-    this.handleDialectFilterChange({
-      facetField,
-      selected,
-      type: this.DIALECT_FILTER_TYPE,
-      unselected,
-    })
-  }
-
-  handleDialectFilterChange = ({ facetField, selected, type, unselected, shouldResetUrlPagination }) => {
-    const { filterInfo } = this.state
-    const { routeParams, splitWindowPath } = this.props
-
-    const newFilter = handleDialectFilterList({
-      facetField,
-      selected,
-      type,
-      unselected,
-      routeParams,
-      filterInfo,
-    })
-
-    // When facets change, pagination should be reset.
-    // In these pages (words/phrase), list views are controlled via URL
-    if (shouldResetUrlPagination === true) {
-      updateUrlIfPageOrPageSizeIsDifferent({
-        // pageSize, // TODO ?
-        // preserveSearch, // TODO ?
-        pushWindowPath: this.props.pushWindowPath,
-        routeParams: routeParams,
-        splitWindowPath: splitWindowPath,
-      })
-    }
-
-    this.setState({ filterInfo: newFilter })
-  }
-
   handleSearch = () => {
     this.changeFilter()
   }
@@ -707,6 +642,35 @@ class WordsFilteredByCategory extends Component {
         categories: currentAppliedFilterCategories,
       }),
     })
+  }
+
+  setDialectFilterCallback = (/*{
+    facetField,
+    href,
+    selected,
+    unselected,
+    updateUrl,
+  }*/) => {
+    this.changeFilter()
+
+    // const newFilter = handleDialectFilterList({
+    //   facetField,
+    //   selected,
+    //   unselected,
+    //   type: 'words',
+    // })
+
+    // // When facets change, pagination should be reset
+    // const { routeParams, splitWindowPath } = this.props
+    // if (shouldResetUrlPagination === true) {
+    //   updateUrlIfPageOrPageSizeIsDifferent({
+    //     pushWindowPath: this.props.pushWindowPath,
+    //     routeParams: routeParams,
+    //     splitWindowPath: splitWindowPath,
+    //   })
+    // }
+
+    // this.setState({ filterInfo: newFilter })
   }
 
   resetSearch = () => {

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/wordsFilteredByCategory.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/wordsFilteredByCategory.js
@@ -35,7 +35,7 @@ import { setRouteParams, updatePageProperties } from 'providers/redux/reducers/n
 // -------------------------------------------
 import AlphabetListView from 'views/components/AlphabetListView'
 import AuthorizationFilter from 'views/components/Document/AuthorizationFilter'
-import DialectFilterList from 'views/components/DialectFilterList'
+import DialectFilterListPresentation from 'views/components/DialectFilterList/DialectFilterListPresentation'
 import Edit from '@material-ui/icons/Edit'
 import FVButton from 'views/components/FVButton'
 import IntlService from 'views/services/intl'
@@ -343,7 +343,7 @@ class WordsFilteredByCategory extends Component {
             <CategoriesDataLayer>
               {({ categoriesData }) => {
                 return (
-                  <DialectFilterList
+                  <DialectFilterListPresentation
                     appliedFilterIds={new Set([routeParams.category])}
                     clearDialectFilter={this.clearDialectFilter}
                     facets={categoriesData}

--- a/frontend/app/assets/stylesheets/main.less
+++ b/frontend/app/assets/stylesheets/main.less
@@ -862,7 +862,6 @@ audio::-webkit-media-controls-enclosure {
 @import "CardView";
 @import "CreateV2";
 @import "Dialect";
-@import "DialectFilterList";
 @import "DialectViewWordPhrase";
 @import "Flashcard";
 @import "FlatButton";


### PR DESCRIPTION
- Extracted Data & Presentation components from branch FW-1234-v2
- Moved .less to co-locate .css
- DialectFilterListData now supports passing in data via the `transformData` prop. Used in combination with the CategoriesDataLayer. When `transformData` exists, DialectFilterListData won't make requests to get the data 