### PR TITLE
Cypress Best Practices

### DIFF
--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -22,14 +22,16 @@ import 'cypress-file-upload'
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
-beforeEach(function() {
-  cy.log('NOTE: Tests are typically run with `npm run startPreprod`')
-  cy.log('NOTE: We will be migrating the tests to dev sandbox soon`')
-})
-afterEach(function() {
+beforeEach(() => {
   // Logout to fix issue with user being logged in between tests.
   cy.logout()
+})
+
+afterEach(() => {
   cy.log('Test complete')
+  // TODO: could we...
+  // TODO: a) not need to wait?
+  // TODO: b) if we do need to wait, only wait when we are recording?
   // Wait to ensure video recording is not cut early on failed test.
   cy.wait(1000)
 })


### PR DESCRIPTION
- Moved logout command from afterEach to beforeEach. A Cypress test could be interrupted and tests that follow may fail since the afterEach logout would not have run - https://docs.cypress.io/guides/references/best-practices.html#Using-after-or-afterEach-hooks
- Removed out of date log messages in beforeEach
- Added some TODO notes to the afterEach wait command (related to video)