### PR TITLE
FW-1395 Add node status servlet

### DIFF
--- a/FirstVoices-marketplace/pom.xml
+++ b/FirstVoices-marketplace/pom.xml
@@ -27,6 +27,10 @@
     </dependency>
     <dependency>
       <groupId>ca.firstvoices</groupId>
+      <artifactId>FirstVoicesHealthMonitor</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ca.firstvoices</groupId>
       <artifactId>FVUserRegistration</artifactId>
     </dependency>
     <dependency>

--- a/FirstVoicesHealthMonitor/pom.xml
+++ b/FirstVoicesHealthMonitor/pom.xml
@@ -1,0 +1,66 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>FirstVoicesHealthMonitor</artifactId>
+  <parent>
+    <groupId>ca.firstvoices</groupId>
+    <artifactId>firstvoices-modules-parent</artifactId>
+    <version>3.4.4-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <name>FirstVoicesHealthMonitor</name>
+  <description></description>
+  <dependencies>
+    <dependency>
+      <groupId>org.nuxeo.common</groupId>
+      <artifactId>nuxeo-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.nuxeo.runtime</groupId>
+      <artifactId>nuxeo-runtime</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.nuxeo.ecm.core</groupId>
+      <artifactId>nuxeo-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.nuxeo.ecm.core</groupId>
+      <artifactId>nuxeo-core-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.seam</groupId>
+      <artifactId>jboss-seam</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.codehaus.jackson</groupId>
+      <artifactId>jackson-mapper-asl</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.nuxeo.ecm.core</groupId>
+      <artifactId>nuxeo-core-io</artifactId>
+    </dependency>
+
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <forkCount>3</forkCount>
+          <reuseForks>true</reuseForks>
+          <argLine>-Xmx1024m -XX:MaxPermSize=256m</argLine>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/FirstVoicesHealthMonitor/pom.xml
+++ b/FirstVoicesHealthMonitor/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>ca.firstvoices</groupId>
     <artifactId>firstvoices-modules-parent</artifactId>
-    <version>3.4.4-SNAPSHOT</version>
+    <version>3.4.5-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <name>FirstVoicesHealthMonitor</name>

--- a/FirstVoicesHealthMonitor/src/main/java/ca/firstvoices/probes/NodeStatusServlet.java
+++ b/FirstVoicesHealthMonitor/src/main/java/ca/firstvoices/probes/NodeStatusServlet.java
@@ -1,0 +1,46 @@
+package ca.firstvoices.probes;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.juli.logging.Log;
+import org.apache.juli.logging.LogFactory;
+import org.nuxeo.runtime.api.Framework;
+
+public class NodeStatusServlet extends HttpServlet {
+
+  private ObjectMapper objectMapper = new ObjectMapper();
+  private static Log log = LogFactory.getLog(NodeStatusServlet.class);
+
+  public static class NodeStatus {
+    public String instanceName;
+    public String clusterID;
+  }
+
+
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+      throws ServletException, IOException {
+
+    NodeStatus status = new NodeStatus();
+
+    try {
+      resp.setStatus(resp.SC_OK);
+      resp.setContentType("application/json");
+
+      status.instanceName = Framework.getProperty("org.nuxeo.ecm.instance.name", "unknown");
+      status.clusterID = Framework.getProperty("repository.clustering.id", "unset");
+
+      objectMapper.writeValue(resp.getOutputStream(), status);
+
+    } catch (Exception e) {
+      log.error("Caught an exception while generating status page", e);
+      resp.setStatus(resp.SC_INTERNAL_SERVER_ERROR);
+    }
+
+  }
+
+}

--- a/FirstVoicesHealthMonitor/src/main/resources/META-INF/MANIFEST.MF
+++ b/FirstVoicesHealthMonitor/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,10 @@
+Manifest-Version: 1.0
+Bundle-SymbolicName: FirstVoicesHealthMonitor
+Bundle-Name: FirstVoicesHealthMonitor
+Bundle-Version: 1.0.qualifier
+Bundle-ClassPath: .
+Bundle-ActivationPolicy: lazy
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-ManifestVersion: 2
+Export-Package: FirstVoicesHealthMonitor
+Bundle-Vendor: Nuxeo

--- a/FirstVoicesHealthMonitor/src/main/resources/OSGI-INF/deployment-fragment.xml
+++ b/FirstVoicesHealthMonitor/src/main/resources/OSGI-INF/deployment-fragment.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<fragment version="1">
+
+    <!-- StatusServlet mapping -->
+    <extension target="web#LAST-SERVLET">
+
+        <servlet>
+            <servlet-name>Nuxeo Instance Status Servlet</servlet-name>
+            <servlet-class>ca.firstvoices.probes.NodeStatusServlet</servlet-class>
+            <load-on-startup>1</load-on-startup>
+        </servlet>
+        <servlet-mapping>
+            <servlet-name>Nuxeo Instance Status Servlet</servlet-name>
+            <url-pattern>/nodestatus</url-pattern>
+        </servlet-mapping>
+
+    </extension>
+
+</fragment>

--- a/FirstVoicesHealthMonitor/src/test/resources/META-INF/MANIFEST.MF
+++ b/FirstVoicesHealthMonitor/src/test/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-SymbolicName: FirstVoicesHealthMonitor.tests

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <module>FirstVoicesPublisher</module>
     <module>FirstVoicesEnrichers</module>
     <module>FirstVoicesSecurity</module>
+    <module>FirstVoicesHealthMonitor</module>
     <module>FirstVoicesExport</module>
     <module>FVUserRegistration</module>
     <module>FirstVoicesMaintenance</module>
@@ -50,6 +51,11 @@
       <dependency>
         <groupId>ca.firstvoices</groupId>
         <artifactId>FirstVoicesSecurity</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>ca.firstvoices</groupId>
+        <artifactId>FirstVoicesHealthMonitor</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
# Changelog
 - Added `/nuxeo/nodestatus` servlet, returning a JSON object containing node cluster ID and instance name.
 - It is not possible to add detailed information to the `/nuxeo/runningstatus` endpoint, since it permits only pass/fail notifications.
 - Recommend this endpoint (and perhaps `/nuxeo/runningstatus`) be guarded by front proxy/balancer