### PR TITLE
FW-1514, FW-1501, FW-1502

### DIFF
--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/base/index.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/base/index.js
@@ -605,7 +605,7 @@ export const sortHandler = async ({
   })
 }
 
-export const updateUrlAfterResetSearch = ({ routeParams, splitWindowPath, pushWindowPath }) => {
+export const updateUrlAfterResetSearch = ({ routeParams, splitWindowPath, pushWindowPath, urlAppend = '' }) => {
   // When facets change, pagination should be reset.
   if (selectn('category', routeParams) || selectn('letter', routeParams) || selectn('phraseBook', routeParams)) {
     let resetUrl = window.location.pathname + ''
@@ -615,7 +615,7 @@ export const updateUrlAfterResetSearch = ({ routeParams, splitWindowPath, pushWi
       _splitWindowPath.splice(learnIndex + 2)
       resetUrl = `/${_splitWindowPath.join('/')}`
     }
-    NavigationHelpers.navigate(resetUrl, pushWindowPath, false)
+    NavigationHelpers.navigate(`${resetUrl}${urlAppend}`, pushWindowPath, false)
   } else {
     // In these pages (words/phrase), list views are controlled via URL
     updateUrlIfPageOrPageSizeIsDifferent({

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/base/toolbar-navigation.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/base/toolbar-navigation.js
@@ -28,7 +28,7 @@ import { pushWindowPath } from 'providers/redux/reducers/windowPath'
 // import selectn from 'selectn'
 // import ProviderHelpers from 'common/ProviderHelpers'
 import NavigationHelpers from 'common/NavigationHelpers'
-
+import Link from 'views/components/Link'
 import EditorInsertChart from '@material-ui/icons/InsertChart'
 import FVButton from 'views/components/FVButton'
 import AuthenticationFilter from 'views/components/Document/AuthenticationFilter'
@@ -50,6 +50,7 @@ export class ToolbarNavigation extends Component {
     computeResultSet: object.isRequired,
     splitWindowPath: array.isRequired,
     windowPath: string.isRequired,
+    pageSize: string.isRequired,
     // REDUX: actions/dispatch/func
     fetchResultSet: func.isRequired,
     navigateTo: func.isRequired,
@@ -89,11 +90,17 @@ export class ToolbarNavigation extends Component {
     }
   }
 
-  _getNavigationURL = (path) => {
+  _getNavigationURL = (path, appendPagination = false) => {
+    let url = ''
     if (this.props.splitWindowPath[this.props.splitWindowPath.length - 1] === 'learn') {
-      return this.props.windowPath + '/' + path
+      url = `${this.props.windowPath}/${path}`
+    } else {
+      url = `${this.props.windowPath}/learn/${path}`
     }
-    return this.props.windowPath + '/learn/' + path
+    if (appendPagination) {
+      url = `${url}/${this.props.pageSize}/1`
+    }
+    return url
   }
 
   render() {
@@ -129,21 +136,21 @@ export class ToolbarNavigation extends Component {
         <div className="row">
           <div className="col-xs-12 col-md-10">
             <div float="left">
-              <a href={this._getNavigationURL('words')} onClick={this._onNavigateRequest.bind(this, 'words')}>
+              <Link href={this._getNavigationURL('words', true)}>
                 <FVLabel transKey="words" defaultStr="Words" transform="first" />
-              </a>
-              <a href={this._getNavigationURL('phrases')} onClick={this._onNavigateRequest.bind(this, 'phrases')}>
+              </Link>
+              <Link href={this._getNavigationURL('phrases', true)}>
                 <FVLabel transKey="phrases" defaultStr="Phrases" transform="first" />
-              </a>
-              <a href={this._getNavigationURL('songs')} onClick={this._onNavigateRequest.bind(this, 'songs')}>
+              </Link>
+              <Link href={this._getNavigationURL('songs')}>
                 <FVLabel transKey="songs" defaultStr="Songs" transform="first" />
-              </a>
-              <a href={this._getNavigationURL('stories')} onClick={this._onNavigateRequest.bind(this, 'stories')}>
+              </Link>
+              <Link href={this._getNavigationURL('stories')}>
                 <FVLabel transKey="stories" defaultStr="Stories" transform="first" />
-              </a>
-              <a href={this._getNavigationURL('alphabet')} onClick={this._onNavigateRequest.bind(this, 'alphabet')}>
+              </Link>
+              <Link href={this._getNavigationURL('alphabet')}>
                 <FVLabel transKey="alphabet" defaultStr="Alphabet" transform="first" />
-              </a>
+              </Link>
             </div>
           </div>
           {this.props.hideStatistics !== true && this.props.isStatisticsVisible !== true && (
@@ -166,17 +173,18 @@ export class ToolbarNavigation extends Component {
 
 // REDUX: reducers/state
 const mapStateToProps = (state /*, ownProps*/) => {
-  const { document, nuxeo, windowPath } = state
+  const { document, nuxeo, navigation, windowPath } = state
 
   const { computeResultSet } = document
   const { computeLogin } = nuxeo
   const { splitWindowPath, _windowPath } = windowPath
-
+  const { pageSize = 10 } = navigation.route.routeParams
   return {
     computeLogin,
     computeResultSet,
     splitWindowPath,
     windowPath: _windowPath,
+    pageSize,
   }
 }
 

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/index.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/index.js
@@ -405,10 +405,6 @@ export class PageDialectLearnPhrases extends PageDialectLearnBase {
         filterInfo: newFilter,
       },
       () => {
-        // When facets change, pagination should be reset.
-        // In these pages (words/phrase), list views are controlled via URL
-        this._resetURLPagination() // NOTE: This function is in PageDialectLearnBase
-
         // Remove alphabet/category filter urls
         if (selectn('routeParams.phraseBook', this.props) || selectn('routeParams.letter', this.props)) {
           let resetUrl = `/${this.props.splitWindowPath.join('/')}`
@@ -419,7 +415,15 @@ export class PageDialectLearnPhrases extends PageDialectLearnBase {
             resetUrl = `/${_splitWindowPath.join('/')}`
           }
 
-          NavigationHelpers.navigate(resetUrl, this.props.pushWindowPath, false)
+          NavigationHelpers.navigate(
+            `${resetUrl}/${this.props.routeParams.pageSize}/1`,
+            this.props.pushWindowPath,
+            false
+          )
+        } else {
+          // When facets change, pagination should be reset.
+          // In these pages (words/phrase), list views are controlled via URL
+          this._resetURLPagination() // NOTE: This function is in PageDialectLearnBase
         }
       }
     )

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/list-view.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/list-view.js
@@ -433,7 +433,20 @@ export class PhrasesListView extends DataListView {
       nql = `${nql}${ProviderHelpers.isStartsWithQuery(currentAppliedFilter)}`
     }
 
-    props.fetchPhrases(this._getPathOrParentID(props), nql)
+    // NOTE: the following attempts to prevent double requests but it doesn't work all the time!
+    // Eventually `this.state.nql` becomes `undefined` and then a duplicate request is initiated
+    //
+    // DataListView calls this._fetchListViewData AND this.fetchData (which calls this.__fetchListViewData)
+    if (this.state.nql !== nql) {
+      this.setState(
+        {
+          nql,
+        },
+        () => {
+          props.fetchPhrases(this._getPathOrParentID(props), nql)
+        }
+      )
+    }
   }
 
   _getPathOrParentID(newProps) {

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/phrasesFilteredByCategory.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/phrases/phrasesFilteredByCategory.js
@@ -597,6 +597,7 @@ export class PhrasesFilteredByCategory extends Component {
           routeParams: this.props.routeParams,
           splitWindowPath: this.props.splitWindowPath,
           pushWindowPath: this.props.pushWindowPath,
+          urlAppend: `/${this.props.routeParams.pageSize}/1`,
         })
       }
     )

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/index.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/index.js
@@ -419,10 +419,6 @@ class PageDialectLearnWords extends PageDialectLearnBase {
         filterInfo: newFilter,
       },
       () => {
-        // When facets change, pagination should be reset.
-        // In these pages (words/phrase), list views are controlled via URL
-        this._resetURLPagination() // NOTE: This function is in PageDialectLearnBase
-
         // Remove alphabet/category filter urls
         if (selectn('routeParams.category', this.props) || selectn('routeParams.letter', this.props)) {
           let resetUrl = `/${this.props.splitWindowPath.join('/')}`
@@ -433,7 +429,15 @@ class PageDialectLearnWords extends PageDialectLearnBase {
             resetUrl = `/${_splitWindowPath.join('/')}`
           }
 
-          NavigationHelpers.navigate(resetUrl, this.props.pushWindowPath, false)
+          NavigationHelpers.navigate(
+            `${resetUrl}/${this.props.routeParams.pageSize}/1`,
+            this.props.pushWindowPath,
+            false
+          )
+        } else {
+          // When facets change, pagination should be reset.
+          // In these pages (words/phrase), list views are controlled via URL
+          this._resetURLPagination() // NOTE: This function is in PageDialectLearnBase
         }
       }
     )

--- a/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/wordsFilteredByCategory.js
+++ b/frontend/app/assets/javascripts/views/pages/explore/dialect/learn/words/wordsFilteredByCategory.js
@@ -618,6 +618,7 @@ class WordsFilteredByCategory extends Component {
           routeParams: this.props.routeParams,
           splitWindowPath: this.props.splitWindowPath,
           pushWindowPath: this.props.pushWindowPath,
+          urlAppend: `/${this.props.routeParams.pageSize}/1`,
         })
       }
     )


### PR DESCRIPTION
https://firstvoices.atlassian.net/browse/FW-1514
Search: not saving settings on 1st search, subsequent searches work correctly

Cause/Background:
- /learn/words is considered different than /learn/words/10/1
- if you search from /learn/words, the results are shown on /learn/words/10/1
- during that transition the SearchDialect values are reset (cause of error)

Changes:
- updated urls to point to words & phrases with pagination included, eg: `/learn/words/10/1` instead of `/learn/words`
- added a check in `.../learn/phrases/list-view.js` to suppress duplicate requests. Fixes the 'old information is briefly displayed' issue