### PR TITLE
FW-73 Addenda - Move user migration to Nuxeo

### DIFF
--- a/FirstVoices-marketplace/src/main/resources/install/templates/first-voices/nuxeo.defaults
+++ b/FirstVoices-marketplace/src/main/resources/install/templates/first-voices/nuxeo.defaults
@@ -16,3 +16,4 @@ fv.cognito.accessKey=ACCESS_KEY_PLACEHOLDER
 fv.cognito.secretKey=SECRET_KEY_PLACEHOLDER
 fv.cognito.clientID=CLIENT_ID_PLACEHOLDER
 fv.cognito.region=ca-central-1
+fv.cognito.blacklistUsers=FVCCAdmin, Administrator

--- a/FirstVoicesCognitoAuth/src/main/java/ca/firstvoices/cognito/AWSAuthenticationService.java
+++ b/FirstVoicesCognitoAuth/src/main/java/ca/firstvoices/cognito/AWSAuthenticationService.java
@@ -24,8 +24,7 @@ public interface AWSAuthenticationService {
   boolean userExists(String username);
 
   /**
-   * Initiate a username and password authentication flow with the given credentials. This can
-   * cause an automatic migration if the Cognito user pool is configured appropriately.
+   * Initiate a username and password authentication flow with the given credentials.
    *
    * @return false when the username exists in Cognito and the password does not match,
    *         false when the username does not exist in Cognito and migration is disabled
@@ -35,6 +34,17 @@ public interface AWSAuthenticationService {
    *                                       migrate a user that does not exist in Nuxeo)
    **/
   boolean authenticate(String username, String password)
+      throws MiscellaneousFailureException;
+
+  /**
+   * Create a user with this username and password in the Cognito database
+   *
+   * @param username
+   * @param password
+   * @param email
+   *
+   */
+  void migrateUser(String username, String password, String email)
       throws MiscellaneousFailureException;
 
   /**

--- a/FirstVoicesCognitoAuth/src/main/java/ca/firstvoices/cognito/AWSAuthenticationServiceFactory.java
+++ b/FirstVoicesCognitoAuth/src/main/java/ca/firstvoices/cognito/AWSAuthenticationServiceFactory.java
@@ -40,7 +40,6 @@ public class AWSAuthenticationServiceFactory extends DefaultComponent {
           this.config.region,
           this.config.clientID
       );
-
       try {
         this.authenticationService.testConnection();
       } catch (MiscellaneousFailureException e) {

--- a/FirstVoicesCognitoAuth/src/main/java/ca/firstvoices/cognito/AWSAwareUserManagerConfigurationDescriptor.java
+++ b/FirstVoicesCognitoAuth/src/main/java/ca/firstvoices/cognito/AWSAwareUserManagerConfigurationDescriptor.java
@@ -12,11 +12,15 @@ public class AWSAwareUserManagerConfigurationDescriptor {
   @XNode("useCognitoAsPrincipalDirectory")
   public boolean useCognitoAsPrincipalDirectory;
 
+  @XNode("blacklistUsers")
+  public String blacklistUsers;
+
   @Override
   public String toString() {
     return "AWSAwareUserManagerConfigurationDescriptor{"
         + "authenticateWithCognito=" + authenticateWithCognito
         + ", useCognitoAsPrincipalDirectory=" + useCognitoAsPrincipalDirectory
+        + ", blackListUsers=" + blacklistUsers
         + '}';
   }
 }

--- a/FirstVoicesCognitoAuth/src/main/resources/OSGI-INF/extensions/ca.firstvoices.cognito.usermanager.xml
+++ b/FirstVoicesCognitoAuth/src/main/resources/OSGI-INF/extensions/ca.firstvoices.cognito.usermanager.xml
@@ -14,6 +14,7 @@
         <configuration>
             <useCognitoAsPrincipalDirectory>false</useCognitoAsPrincipalDirectory>
             <authenticateWithCognito>${fv.cognito.authenticateWithCognito}</authenticateWithCognito>
+            <blacklistUsers>${fv.cognito.blacklistUsers}</blacklistUsers>
         </configuration>
     </extension>
 

--- a/FirstVoicesCognitoAuth/src/test/java/ca/firstvoices/cognito/TestAWSAuthenticationServiceFactory.java
+++ b/FirstVoicesCognitoAuth/src/test/java/ca/firstvoices/cognito/TestAWSAuthenticationServiceFactory.java
@@ -86,7 +86,13 @@ public class TestAWSAuthenticationServiceFactory extends DefaultComponent {
     }
 
     @Override
-    public void updatePassword(String username, String password) throws MiscellaneousFailureException {
+    public void updatePassword(String username, String password)
+        throws MiscellaneousFailureException {
+    }
+
+    @Override
+    public void migrateUser(String username, String password, String email)
+        throws MiscellaneousFailureException {
 
     }
   }

--- a/FirstVoicesCognitoAuth/src/test/resources/ca.firstvoices.cognito.usermanager.xml
+++ b/FirstVoicesCognitoAuth/src/test/resources/ca.firstvoices.cognito.usermanager.xml
@@ -14,6 +14,7 @@
         <configuration>
             <useCognitoAsPrincipalDirectory>false</useCognitoAsPrincipalDirectory>
             <authenticateWithCognito>true</authenticateWithCognito>
+            <blacklistUsers>Administrator, TestAdmin</blacklistUsers>
         </configuration>
     </extension>
 


### PR DESCRIPTION
Changelog
 - Added `fv.cognito.blacklistUsers` configuration option. Users in this list will always be authenticated locally and will never be migrated (use for Admin accounts). Comma-separated list.
 - Moved Cognito user migration into Nuxeo process.
 - Stripped unnecessary AWS SDK components from the build

Deployment notes:
 - Remove lambda migration trigger prior to deployment from within Cognito console
