### PR TITLE
AudioMinimal components (Data, Presentation, Container, DataSource) and related Redux reducer

### DIFF
--- a/frontend/app/assets/javascripts/common/DataSource/useAudio.js
+++ b/frontend/app/assets/javascripts/common/DataSource/useAudio.js
@@ -1,0 +1,15 @@
+import { useDispatch, useSelector } from 'react-redux'
+import { setPlaying as _setPlaying, stopPlaying as _stopPlaying } from 'providers/redux/reducers/audio'
+function useAudio() {
+  const dispatch = useDispatch()
+  return {
+    lastPlayed: useSelector((state) => state.audio.lastPlayed),
+    setLastPlayed: (src) => {
+      dispatch(_setPlaying(src))
+    },
+    clearLastPlayed: () => {
+      dispatch(_stopPlaying())
+    },
+  }
+}
+export default useAudio

--- a/frontend/app/assets/javascripts/components/AudioMinimal/AudioMinimalContainer.js
+++ b/frontend/app/assets/javascripts/components/AudioMinimal/AudioMinimalContainer.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import AudioMinimalPresentation from './AudioMinimalPresentation'
+import AudioMinimalData from './AudioMinimalData'
+
+/**
+ * @summary AudioMinimalContainer
+ * @version 1.0.1
+ * @component
+ *
+ * @param {object} props
+ * @param {string} props.src URL for audio file
+ *
+ * @returns {node} jsx markup
+ */
+function AudioMinimalContainer(props) {
+  return (
+    <AudioMinimalData src={props.src}>
+      {({ isPlaying, onPlay, onPause }) => {
+        return <AudioMinimalPresentation isPlaying={isPlaying} onPlay={onPlay} onPause={onPause} />
+      }}
+    </AudioMinimalData>
+  )
+}
+// PROPTYPES
+const { string } = PropTypes
+AudioMinimalContainer.propTypes = {
+  src: string,
+}
+
+export default AudioMinimalContainer

--- a/frontend/app/assets/javascripts/components/AudioMinimal/AudioMinimalData.js
+++ b/frontend/app/assets/javascripts/components/AudioMinimal/AudioMinimalData.js
@@ -1,0 +1,65 @@
+import PropTypes from 'prop-types'
+import useAudio from 'DataSource/useAudio'
+import { useEffect, useState } from 'react'
+/**
+ * @summary AudioMinimalData
+ * @version 1.0.1
+ * @component
+ *
+ * @param {object} props
+ * @param {string} props.src URL to audio file
+ * @param {function} props.children props.children({ isPlaying, onPlay, onPause })
+ * @see {@link AudioMinimalPresentation} for info on the children callback object
+ */
+function AudioMinimalData({ children, src }) {
+  const [player] = useState(new Audio(src))
+  const [isPlaying, setIsPlaying] = useState(false)
+  const { lastPlayed, setLastPlayed, clearLastPlayed } = useAudio()
+
+  const onPlay = () => {
+    setLastPlayed(src)
+    setIsPlaying(true)
+    player.currentTime = 0
+    player.play()
+  }
+  const onPause = () => {
+    setIsPlaying(false)
+    player.pause()
+  }
+  player.onended = () => {
+    if (lastPlayed === src) {
+      clearLastPlayed()
+      setIsPlaying(false)
+    }
+  }
+
+  // Stops any in play audio
+  useEffect(() => {
+    if (lastPlayed !== src && isPlaying) {
+      onPause()
+    }
+  }, [lastPlayed])
+
+  // Stops audio on unload
+  useEffect(() => {
+    return () => {
+      onPause()
+      clearLastPlayed()
+    }
+  }, [])
+
+  return children({
+    isPlaying,
+    onPlay,
+    onPause,
+  })
+}
+
+// PROPTYPES
+const { string, func } = PropTypes
+AudioMinimalData.propTypes = {
+  src: string.isRequired,
+  children: func.isRequired,
+}
+
+export default AudioMinimalData

--- a/frontend/app/assets/javascripts/components/AudioMinimal/AudioMinimalPresentation.js
+++ b/frontend/app/assets/javascripts/components/AudioMinimal/AudioMinimalPresentation.js
@@ -1,0 +1,57 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import AVPlayArrow from '@material-ui/icons/PlayArrow'
+import AVStop from '@material-ui/icons/Stop'
+
+/**
+ * @summary AudioMinimalPresentation
+ * @version 1.0.1
+ * @component
+ *
+ * @param {object} props
+ * @param {boolean} [props.isPlaying] Flag used to toggle the play/pause buttons. Default: false
+ * @param {function} [props.onPause] Callback when paused. Default: () => {}
+ * @param {function} [props.onPlay] Callback when played. Default: () => {}
+ * @param {boolean} [props.shouldStopPropagation] Flag for event.stopPropagation() when clicking on buttons. Default: true
+ *
+ * @returns {node} jsx markup
+ */
+function AudioMinimalPresentation({ isPlaying, onPause, onPlay, shouldStopPropagation }) {
+  return isPlaying ? (
+    <AVStop
+      color="secondary"
+      onClick={(event) => {
+        if (shouldStopPropagation) {
+          event.stopPropagation()
+        }
+        onPause()
+      }}
+    />
+  ) : (
+    <AVPlayArrow
+      color="secondary"
+      onClick={(event) => {
+        if (shouldStopPropagation) {
+          event.stopPropagation()
+        }
+        onPlay()
+      }}
+    />
+  )
+}
+// PROPTYPES
+const { func, bool } = PropTypes
+AudioMinimalPresentation.propTypes = {
+  isPlaying: bool,
+  onPause: func,
+  onPlay: func,
+  shouldStopPropagation: bool,
+}
+AudioMinimalPresentation.defaultProps = {
+  shouldStopPropagation: true,
+  isPlaying: false,
+  onPause: () => {},
+  onPlay: () => {},
+}
+
+export default AudioMinimalPresentation

--- a/frontend/app/assets/javascripts/components/AudioMinimal/index.js
+++ b/frontend/app/assets/javascripts/components/AudioMinimal/index.js
@@ -1,0 +1,9 @@
+import AudioMinimalContainer from './AudioMinimalContainer'
+import AudioMinimalPresentation from './AudioMinimalPresentation'
+import AudioMinimalData from './AudioMinimalData'
+
+export default {
+  Container: AudioMinimalContainer,
+  Presentation: AudioMinimalPresentation,
+  Data: AudioMinimalData,
+}

--- a/frontend/app/assets/javascripts/providers/redux/reducers/audio/actionTypes.js
+++ b/frontend/app/assets/javascripts/providers/redux/reducers/audio/actionTypes.js
@@ -1,0 +1,2 @@
+export const AUDIO_START = 'AUDIO_START'
+export const AUDIO_STOP = 'AUDIO_STOP'

--- a/frontend/app/assets/javascripts/providers/redux/reducers/audio/actions.js
+++ b/frontend/app/assets/javascripts/providers/redux/reducers/audio/actions.js
@@ -1,0 +1,14 @@
+import { AUDIO_START, AUDIO_STOP } from './actionTypes'
+
+export const setPlaying = (src) => {
+  return (dispatch) => {
+    dispatch({ type: AUDIO_STOP })
+    dispatch({ type: AUDIO_START, src })
+  }
+}
+
+export const stopPlaying = () => {
+  return (dispatch) => {
+    dispatch({ type: AUDIO_STOP })
+  }
+}

--- a/frontend/app/assets/javascripts/providers/redux/reducers/audio/index.js
+++ b/frontend/app/assets/javascripts/providers/redux/reducers/audio/index.js
@@ -1,0 +1,3 @@
+export * from './actions'
+export * from './actionTypes'
+export * from './reducer'

--- a/frontend/app/assets/javascripts/providers/redux/reducers/audio/reducer.js
+++ b/frontend/app/assets/javascripts/providers/redux/reducers/audio/reducer.js
@@ -1,0 +1,17 @@
+import { combineReducers } from 'redux'
+import { AUDIO_START, AUDIO_STOP } from './actionTypes'
+
+export const audioReducer = combineReducers({
+  lastPlayed(state = '', action) {
+    switch (action.type) {
+      case AUDIO_STOP:
+        return ''
+
+      case AUDIO_START:
+        return action.src
+
+      default:
+        return state
+    }
+  },
+})

--- a/frontend/app/assets/javascripts/providers/redux/reducers/index.js
+++ b/frontend/app/assets/javascripts/providers/redux/reducers/index.js
@@ -1,4 +1,5 @@
 import { combineReducers } from 'redux'
+import { audioReducer } from './audio'
 import { directoryReducer } from './directory'
 import { documentReducer } from './document'
 import { errorReducer } from './error'
@@ -34,6 +35,7 @@ import { tasksReducer } from './tasks'
 import { windowPathReducer } from './windowPath'
 
 export default combineReducers({
+  audio: audioReducer,
   directory: directoryReducer,
   document: documentReducer,
   error: errorReducer,


### PR DESCRIPTION
The PR for `FW-1481-kids-phrases` is a bit too large so I'm pulling out features that can be PRed separately.

Adds new AudioMinimal components (Data, Presentation, Container, DataSource) and related Redux reducer

Features:
- Easy to use, just need a url to the audio: ```<AudioMinimal.Container src={audio} />```
- Plays one file at a time. Stops any in-progress audio before starting new audio
- Stops audio on unmount

<img width="178" alt="AudioMinimal Playing" src="https://user-images.githubusercontent.com/748860/84808090-096c6580-afbd-11ea-8917-720945bfc308.png">
<img width="196" alt="AudioMinimal Stopped" src="https://user-images.githubusercontent.com/748860/84808092-0a04fc00-afbd-11ea-9ebb-f46db905698c.png">

