### PR TITLE
FW-1667: Update NXQL Query For Custom Order Recompute

### DIFF
--- a/FirstVoicesPublisher/src/main/java/ca/firstvoices/nativeorder/listeners/ComputeNativeOrderDialectListener.java
+++ b/FirstVoicesPublisher/src/main/java/ca/firstvoices/nativeorder/listeners/ComputeNativeOrderDialectListener.java
@@ -46,7 +46,8 @@ public class ComputeNativeOrderDialectListener implements EventListener {
 
                 String query = "SELECT * FROM FVAlphabet "
                     + "WHERE fv-alphabet:custom_order_recompute_required = 1 "
-                    + "AND fv-alphabet:update_confusables_required=0 " + "AND ecm:isProxy = 0 "
+                    + "AND (fv-alphabet:update_confusables_required=0 OR "
+                    + "fv-alphabet:update_confusables_required IS NULL)" + "AND ecm:isProxy = 0 "
                     + "AND ecm:isCheckedInVersion = 0 " + "AND ecm:isTrashed = 0";
                 DocumentModelList alphabets = session.query(query);
 


### PR DESCRIPTION
Before this change, if this flag had not been initialized on an alphabet document: “fv-alphabet:update_confusables_required", the customOrderRecompute query would not pick up the alphabet document because of the query.
