### PR TITLE
FW-1607

### DIFF
--- a/frontend/app/assets/javascripts/components/ListTasks/ListTasksData.js
+++ b/frontend/app/assets/javascripts/components/ListTasks/ListTasksData.js
@@ -61,7 +61,7 @@ function ListTasksData({ children, columnRender }) {
       const uid = selectn('uid', dialect)
       return {
         href: uid ? `/tasks/users/${uid}` : '#',
-        dialectName: selectn(['properites', 'dc:title'], dialect),
+        dialectName: selectn(['properties', 'dc:title'], dialect),
       }
     })
   }


### PR DESCRIPTION
Fixes missing dialect name when registration tasks are displayed

Bug:
<img width="656" alt="Screen Shot 2020-07-06 at 11 05 12 AM" src="https://user-images.githubusercontent.com/748860/86624675-967d5b80-bf78-11ea-9b74-ca29dcc3021c.png">
