### PR TITLE
FW-1708 Site crashes on word view w/small screens when on /sections

### DIFF
--- a/frontend/app/assets/javascripts/components/WordsList/WordsListData.js
+++ b/frontend/app/assets/javascripts/components/WordsList/WordsListData.js
@@ -41,6 +41,7 @@ import {
   dictionaryListSmallScreenColumnDataTemplateCustomAudio,
   dictionaryListSmallScreenColumnDataTemplateCustomInspectChildrenCellRender,
   dictionaryListSmallScreenTemplateWords,
+  dictionaryListSmallScreenColumnDataTemplateCustomState,
 } from 'views/components/Browsing/DictionaryListSmallScreen'
 
 /**
@@ -302,6 +303,8 @@ function WordsListData({ children }) {
       columnsArray.push({
         name: 'state',
         title: intl.trans('state', 'State', 'first'),
+        columnDataTemplate: dictionaryListSmallScreenColumnDataTemplate.custom,
+        columnDataTemplateCustom: dictionaryListSmallScreenColumnDataTemplateCustomState,
       })
     }
     return columnsArray

--- a/frontend/app/assets/javascripts/views/components/Browsing/DictionaryListSmallScreen.js
+++ b/frontend/app/assets/javascripts/views/components/Browsing/DictionaryListSmallScreen.js
@@ -110,6 +110,7 @@ const DictionaryListSmallScreen = (props) => {
         }
       })
 
+      // First & Last Name
       templateData[firstLastName] =
         _firstName || _lastName ? (
           <div className={`${classNameDataItem} ${classNameDataItem}--firstNameLastName`}>
@@ -296,9 +297,9 @@ export const dictionaryListSmallScreenColumnDataTemplateCustomAudio = ({ cellRen
   return cellRender ? <div className={`DictionaryListSmallScreen__audioGroup ${className}`}>{cellRender}</div> : null
 }
 
-// dictionaryListSmallScreenTemplateWords
+// dictionaryListSmallScreenColumnDataTemplateCustomState
 // --------------------------------------------------------------
-export const dictionaryListSmallScreenTemplateWords = ({ templateData }) => {
+export const dictionaryListSmallScreenColumnDataTemplateCustomState = ({ cellRender, className = '' }) => {
   const { routeParams } = useRoute()
   const dialectName = routeParams.dialect_name
   const mapDocumentStateToVisibility = {
@@ -307,6 +308,18 @@ export const dictionaryListSmallScreenTemplateWords = ({ templateData }) => {
     Enabled: `${dialectName} Members Only`,
     Published: 'Public',
   }
+  const stateVisibilityText = mapDocumentStateToVisibility[cellRender]
+  return cellRender ? (
+    <div className={`DictionaryListSmallScreen__stateGroup ${className}`}>
+      <strong>State: </strong>
+      {stateVisibilityText ? stateVisibilityText : ''}
+    </div>
+  ) : null
+}
+
+// dictionaryListSmallScreenTemplateWords
+// --------------------------------------------------------------
+export const dictionaryListSmallScreenTemplateWords = ({ templateData }) => {
   return (
     <div className="DictionaryListSmallScreen__item">
       <div className="DictionaryListSmallScreen__groupMain">
@@ -329,10 +342,7 @@ export const dictionaryListSmallScreenTemplateWords = ({ templateData }) => {
 
         <div className="DictionaryListSmallScreen__groupMainMiscellaneous">
           <div className="DictionaryListSmallScreen__groupData">{templateData['fv-word:categories']}</div>
-          <div className="DictionaryListSmallScreen__groupData">
-            <strong>State: </strong>
-            {mapDocumentStateToVisibility[templateData.state.props.children[2]]}
-          </div>
+          <div className="DictionaryListSmallScreen__groupData">{templateData.state}</div>
         </div>
       </div>
 


### PR DESCRIPTION
- Triggered by accessing deeply nested object that is undefined when on `sections`
- Created a custom template to render State and enabled it over in `getColumns()`