### PR TITLE
FW-1707: Allow Publish Transition from Disabled State

### DIFF
--- a/FirstVoicesData/src/main/resources/OSGI-INF/lifecycle/ca.firstvoices.lifecycle.fv-lifecycle.xml
+++ b/FirstVoicesData/src/main/resources/OSGI-INF/lifecycle/ca.firstvoices.lifecycle.fv-lifecycle.xml
@@ -22,6 +22,7 @@
           name="Disabled">
           <transitions>
             <transition>Enable</transition>
+            <transition>Publish</transition>
           </transitions>
         </state>
         <state description="" name="Published">


### PR DESCRIPTION
Categories.Migrate was failing with an error stating that we can't trigger Publish Transition from Disabled State. Since this is a workflow allowed elsewhere with the new tasks, and this fix worked on the hotfix branch, pushing up to Master.