### PR TITLE
FW-1739 Fix addConfusables failing character validation

### DIFF
--- a/FirstVoicesData/src/main/java/ca/firstvoices/listeners/FVDocumentListener.java
+++ b/FirstVoicesData/src/main/java/ca/firstvoices/listeners/FVDocumentListener.java
@@ -111,7 +111,7 @@ public class FVDocumentListener extends AbstractFirstVoicesDataListener {
 
     if (event.getName().equals(DocumentEventTypes.ABOUT_TO_CREATE)) {
       cleanupWordsAndPhrases();
-      validateCharacter();
+      validateCharacter(document);
     }
 
     if (event.getName().equals(DocumentEventTypes.DOCUMENT_CREATED)) {
@@ -120,7 +120,7 @@ public class FVDocumentListener extends AbstractFirstVoicesDataListener {
 
     if (event.getName().equals(DocumentEventTypes.BEFORE_DOC_UPDATE)) {
       cleanupWordsAndPhrases();
-      validateCharacter();
+      validateCharacter(document);
     }
 
     if (event.getName().equals(DocumentEventTypes.DOCUMENT_UPDATED)) {
@@ -178,23 +178,23 @@ public class FVDocumentListener extends AbstractFirstVoicesDataListener {
     }
   }
 
-  public void validateCharacter() {
-    if (document.getDocumentType().getName().equals(FV_CHARACTER) && !document.isProxy()
-        && !document.isVersion()) {
+  public void validateCharacter(DocumentModel characterDoc) {
+    if (characterDoc.getDocumentType().getName().equals(FV_CHARACTER) && !characterDoc.isProxy()
+        && !characterDoc.isVersion()) {
       try {
-        DocumentModelList characters = getCharacters(document);
-        DocumentModel alphabet = getAlphabet(document);
+        DocumentModelList characters = getCharacters(characterDoc);
+        DocumentModel alphabet = getAlphabet(characterDoc);
 
         if (event.getName().equals(DocumentEventTypes.BEFORE_DOC_UPDATE)) {
           //All character documents except for the modified doc
           List<DocumentModel> filteredCharacters = characters.stream()
-              .filter(c -> !c.getId().equals(document.getId()))
+              .filter(c -> !c.getId().equals(characterDoc.getId()))
               .collect(Collectors.toList());
-          cleanupCharactersService.validateCharacters(filteredCharacters, alphabet, document);
+          cleanupCharactersService.validateCharacters(filteredCharacters, alphabet, characterDoc);
         }
 
         if (event.getName().equals(DocumentEventTypes.ABOUT_TO_CREATE)) {
-          cleanupCharactersService.validateCharacters(characters, alphabet, document);
+          cleanupCharactersService.validateCharacters(characters, alphabet, characterDoc);
 
         }
 
@@ -205,14 +205,14 @@ public class FVDocumentListener extends AbstractFirstVoicesDataListener {
     }
 
     //If doc is alphabet, do another operation for ignored characters
-    if (document.getDocumentType().getName().equals(FV_ALPHABET) && !document.isProxy()
-        && !document.isVersion()) {
+    if (characterDoc.getDocumentType().getName().equals(FV_ALPHABET) && !characterDoc.isProxy()
+        && !characterDoc.isVersion()) {
       try {
 
         //only test on update, not creation as characters will not exist during creation
         if (event.getName().equals(DocumentEventTypes.BEFORE_DOC_UPDATE)) {
-          DocumentModelList characters = getCharacters(document);
-          DocumentModel alphabet = getAlphabet(document);
+          DocumentModelList characters = getCharacters(characterDoc);
+          DocumentModel alphabet = getAlphabet(characterDoc);
           cleanupCharactersService.validateAlphabetIgnoredCharacters(characters, alphabet);
 
         }

--- a/FirstVoicesData/src/main/java/ca/firstvoices/services/AddConfusablesService.java
+++ b/FirstVoicesData/src/main/java/ca/firstvoices/services/AddConfusablesService.java
@@ -28,8 +28,8 @@ public interface AddConfusablesService {
   /**
    * Add confusables will copy values from the default list of confusables to each character
    *
-   * @param session
-   * @param dialect
+   * @param session Nuxeo session.
+   * @param dialect Dialect to add confusables to.
    */
   void addConfusables(CoreSession session, DocumentModel dialect);
 

--- a/FirstVoicesData/src/main/java/ca/firstvoices/services/AddConfusablesService.java
+++ b/FirstVoicesData/src/main/java/ca/firstvoices/services/AddConfusablesService.java
@@ -25,6 +25,12 @@ import org.nuxeo.ecm.core.api.DocumentModel;
 
 public interface AddConfusablesService {
 
+  /**
+   * Add confusables will copy values from the default list of confusables to each character
+   *
+   * @param session
+   * @param dialect
+   */
   void addConfusables(CoreSession session, DocumentModel dialect);
 
   DocumentModel updateConfusableCharacters(CoreSession session, DocumentModel characterDocument,

--- a/FirstVoicesData/src/main/java/ca/firstvoices/services/CleanupCharactersService.java
+++ b/FirstVoicesData/src/main/java/ca/firstvoices/services/CleanupCharactersService.java
@@ -28,19 +28,19 @@ import org.nuxeo.ecm.core.api.DocumentModel;
 public interface CleanupCharactersService {
 
   /**
-   * @param session
-   * @param document
+   * @param session      Nuxeo session.
+   * @param document     Document to be cleaned.
    * @param saveDocument whether or not to save the document. not necessary if saving is done later
    *                     (e.g. aboutToCreate)
-   * @return
+   * @return Cleaned document
    */
   DocumentModel cleanConfusables(CoreSession session, DocumentModel document, Boolean saveDocument);
 
   /**
    * Ensures all characters and confusables are unique.
    *
-   * @param characters
-   * @param alphabet
+   * @param characters List of FVCharacter documents that are not the document being updated.
+   * @param alphabet   The alphabet document corresponding to the characters.
    * @param updated    The character document being updated.
    */
   void validateCharacters(List<DocumentModel> characters,
@@ -49,8 +49,8 @@ public interface CleanupCharactersService {
   /**
    * Ensures ignored characters are unique from characters and confusables.
    *
-   * @param characters
-   * @param alphabet
+   * @param characters List of FVCharacter documents for the alphabet.
+   * @param alphabet   Alphabet document.
    */
   void validateAlphabetIgnoredCharacters(List<DocumentModel> characters,
       DocumentModel alphabet);
@@ -59,8 +59,8 @@ public interface CleanupCharactersService {
    * A map of all upper/lowercase characters, upper/lowercase confusables and ignored characters
    * currently in the dialect.
    *
-   * @param dialect
-   * @return
+   * @param dialect Dialect containing desired documents
+   * @return Map of all upper/lowercase characters, confusables and ignored characters
    */
   Set<String> getCharactersToSkipForDialect(DocumentModel dialect);
 }

--- a/FirstVoicesData/src/main/java/ca/firstvoices/services/CleanupCharactersService.java
+++ b/FirstVoicesData/src/main/java/ca/firstvoices/services/CleanupCharactersService.java
@@ -21,6 +21,7 @@
 package ca.firstvoices.services;
 
 import java.util.List;
+import java.util.Set;
 import org.nuxeo.ecm.core.api.CoreSession;
 import org.nuxeo.ecm.core.api.DocumentModel;
 
@@ -35,9 +36,31 @@ public interface CleanupCharactersService {
    */
   DocumentModel cleanConfusables(CoreSession session, DocumentModel document, Boolean saveDocument);
 
+  /**
+   * Ensures all characters and confusables are unique.
+   *
+   * @param characters
+   * @param alphabet
+   * @param updated    The character document being updated.
+   */
   void validateCharacters(List<DocumentModel> characters,
       DocumentModel alphabet, DocumentModel updated);
 
+  /**
+   * Ensures ignored characters are unique from characters and confusables.
+   *
+   * @param characters
+   * @param alphabet
+   */
   void validateAlphabetIgnoredCharacters(List<DocumentModel> characters,
       DocumentModel alphabet);
+
+  /**
+   * A map of all upper/lowercase characters, upper/lowercase confusables and ignored characters
+   * currently in the dialect.
+   *
+   * @param dialect
+   * @return
+   */
+  Set<String> getCharactersToSkipForDialect(DocumentModel dialect);
 }

--- a/FirstVoicesData/src/main/java/ca/firstvoices/services/CleanupCharactersServiceImpl.java
+++ b/FirstVoicesData/src/main/java/ca/firstvoices/services/CleanupCharactersServiceImpl.java
@@ -177,7 +177,7 @@ public class CleanupCharactersServiceImpl extends AbstractFirstVoicesDataService
       for (String str : lowerConfusableStrArr) {
         if (!updatedDocumentCharacters.add(str)) {
           throw new FVCharacterInvalidException(
-              "A character is duplicated somewhere in this document's uppercase, "
+              "The character " + str + " is duplicated somewhere in this document's uppercase,"
                   + "lowercase or confusable characters ",
               400);
         }
@@ -190,7 +190,7 @@ public class CleanupCharactersServiceImpl extends AbstractFirstVoicesDataService
       for (String str : upperConfusableStrArr) {
         if (!updatedDocumentCharacters.add(str)) {
           throw new FVCharacterInvalidException(
-              "A character is duplicated somewhere in this document's uppercase, "
+              "The character " + str + " is duplicated somewhere in this document's uppercase,"
                   + "lowercase or confusable characters ",
               400);
         }
@@ -206,11 +206,13 @@ public class CleanupCharactersServiceImpl extends AbstractFirstVoicesDataService
       collectedCharacters.addAll(Arrays.asList(ignoredCharacters));
     }
 
+    String updatedCharacterSet = String.join(",", updatedDocumentCharacters);
+    String collectedCharacterSet = String.join(",", collectedCharacters);
     //Confirm that updated character set is unique from all other characters
     if (!Collections.disjoint(updatedDocumentCharacters, collectedCharacters)) {
       throw new FVCharacterInvalidException(
-          "The updated character includes a duplicate character "
-              + "found in another character document",
+          "The updated character set:\n" + updatedCharacterSet + "\nincludes a duplicate character"
+              + " found in the character set:\n" + collectedCharacterSet,
           400);
     }
   }
@@ -229,7 +231,7 @@ public class CleanupCharactersServiceImpl extends AbstractFirstVoicesDataService
       for (String str : ignoredCharsArr) {
         if (!collectedCharacters.add(str)) {
           throw new FVCharacterInvalidException(
-              "The ignored characters list includes a duplicate character "
+              "The ignored character " + str + " is a duplicate character "
                   + "found in another character document",
               400);
         }

--- a/FirstVoicesData/src/main/java/ca/firstvoices/services/CleanupCharactersServiceImpl.java
+++ b/FirstVoicesData/src/main/java/ca/firstvoices/services/CleanupCharactersServiceImpl.java
@@ -223,6 +223,8 @@ public class CleanupCharactersServiceImpl extends AbstractFirstVoicesDataService
   public Set<String> getCharactersToSkipForDialect(DocumentModel dialect) {
     DocumentModelList characters = getCharacters(dialect);
     DocumentModel alphabet = getAlphabet(dialect);
+    //Alphabet must not be null.
+    assert alphabet != null;
 
     Set<String> charactersToSkip = createCharacterHashMap(characters);
     String[] ignoredCharacters = (String[]) alphabet
@@ -320,6 +322,8 @@ public class CleanupCharactersServiceImpl extends AbstractFirstVoicesDataService
 
   private DocumentModelList getCharacters(DocumentModel doc) {
     DocumentModel alphabet = getAlphabet(doc);
+    //Alphabet must not be null
+    assert alphabet != null;
     return doc.getCoreSession().getChildren(alphabet.getRef());
   }
 

--- a/FirstVoicesData/src/main/java/ca/firstvoices/services/CleanupCharactersServiceImpl.java
+++ b/FirstVoicesData/src/main/java/ca/firstvoices/services/CleanupCharactersServiceImpl.java
@@ -159,10 +159,15 @@ public class CleanupCharactersServiceImpl extends AbstractFirstVoicesDataService
     //lower case char, upper case char, lower confusable list and upper confusable list are unique
     Set<String> updatedDocumentCharacters = new HashSet<>();
 
-    updatedDocumentCharacters
-        .add((String) updated.getPropertyValue(DOCUMENT_TITLE));
-    updatedDocumentCharacters
-        .add((String) updated.getPropertyValue("fvcharacter:upper_case_character"));
+    String docTitle = (String) updated.getPropertyValue(DOCUMENT_TITLE);
+    if (docTitle != null) {
+      updatedDocumentCharacters.add(docTitle);
+    }
+
+    String upperChar = (String) updated.getPropertyValue("fvcharacter:upper_case_character");
+    if (upperChar != null) {
+      updatedDocumentCharacters.add(upperChar);
+    }
 
     //must loop through each confusable individually
     //as addAll would return true if the confusable string list had duplicates AND new values
@@ -236,9 +241,15 @@ public class CleanupCharactersServiceImpl extends AbstractFirstVoicesDataService
     Set<String> collectedCharacters = new HashSet<>();
 
     for (DocumentModel d : characters) {
-      collectedCharacters.add((String) d.getPropertyValue(DOCUMENT_TITLE));
-      collectedCharacters.add((String) d.getPropertyValue("fvcharacter:upper_case_character"));
+      String docTitle = (String) d.getPropertyValue(DOCUMENT_TITLE);
+      if (docTitle != null) {
+        collectedCharacters.add(docTitle);
+      }
 
+      String upperChar = (String) d.getPropertyValue("fvcharacter:upper_case_character");
+      if (upperChar != null) {
+        collectedCharacters.add(upperChar);
+      }
 
       String[] lowerConfusablesArr = (String[]) d
           .getPropertyValue("fvcharacter:confusable_characters");

--- a/FirstVoicesData/src/test/java/ca/firstvoices/services/AddConfusablesServiceImplTest.java
+++ b/FirstVoicesData/src/test/java/ca/firstvoices/services/AddConfusablesServiceImplTest.java
@@ -24,6 +24,8 @@ import static ca.firstvoices.schemas.DialectTypesConstants.FV_CHARACTER;
 import static org.junit.Assert.assertNotNull;
 
 import ca.firstvoices.testUtil.AbstractFirstVoicesDataTest;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 import org.nuxeo.ecm.core.api.DocumentModel;
@@ -65,6 +67,32 @@ public class AddConfusablesServiceImplTest extends AbstractFirstVoicesDataTest {
 
     Assert.assertTrue(uProperty[0].equals(confusablesToAdd[0]));
     Assert.assertTrue(uProperty[1].equals(confusablesToAdd[1]));
+  }
+
+  @Test
+  public void ignoreConfusablesAlreadyUsed() {
+    String[] confusablesToAdd = {"ā", "a̅", "ā", "ā", "a¯", "a‾"};
+
+    assertNotNull("Dialect cannot be null", dialect);
+    String path = alphabet.getPathAsString();
+
+    DocumentModel confusableWithUppercase = createDocument(session,
+        session.createDocumentModel(path, "ā", FV_CHARACTER));
+    confusableWithUppercase.setPropertyValue("dc:title", "ā");
+    confusableWithUppercase.setPropertyValue("fvcharacter:upper_case_character", "a‾");
+    session.saveDocument(confusableWithUppercase);
+
+    DocumentModel addedConfusables = session.saveDocument(addConfusablesService
+        .updateConfusableCharacters(session, confusableWithUppercase, dialect, "ā",
+            confusablesToAdd));
+
+    List<String> confusableList = Arrays
+        .asList((String[]) addedConfusables.getPropertyValue("fvcharacter:confusable_characters"));
+
+    //Assert.assertEquals(5, confusableList.size());
+    Assert.assertFalse(confusableList.contains("ā"));
+    Assert.assertFalse(confusableList.contains("a‾"));
+
   }
 
 }

--- a/FirstVoicesData/src/test/java/ca/firstvoices/services/CleanupCharactersServiceImplTest.java
+++ b/FirstVoicesData/src/test/java/ca/firstvoices/services/CleanupCharactersServiceImplTest.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -137,6 +138,13 @@ public class CleanupCharactersServiceImplTest extends AbstractFirstVoicesDataTes
     for (DocumentModel doc : characters) {
       cleanupCharactersService.validateCharacters(characters, alphabet, doc);
     }
+  }
+
+  @Test
+  public void getCharactersToSkip() {
+    setupCharacters();
+    Set<String> collectedMap = cleanupCharactersService.getCharactersToSkipForDialect(dialect);
+    assertEquals(18, collectedMap.size());
   }
 
   private void setupCharacters() {


### PR DESCRIPTION
- validateCharacters method can now handle documents with null upper case values
- validateCharacter method now takes a document as a parameter for clarity
- FVCharacterInvalid exceptions now display the invalid characters or hash maps
- Adding confusables now skips confusables that are already a part of a dialect's alphabet
- Added some documentation comments for clarity