### PR TITLE
FW-1624 Sorting on widget & detail view

### DIFF
--- a/frontend/app/assets/javascripts/common/DataSource/useDashboard.js
+++ b/frontend/app/assets/javascripts/common/DataSource/useDashboard.js
@@ -36,7 +36,10 @@ function useDashboard() {
 
   const formatTasksData = (_tasks) => {
     const formatDate = (date) => StringHelpers.formatUTCDateString(date)
-    const formatInitator = ({ firstName, lastName }) => `${firstName ? firstName : ''} ${lastName ? lastName : ''}`
+    const formatInitator = ({ email, firstName, lastName }) => {
+      const fullName = `${firstName ? firstName : ''} ${lastName ? lastName : ''}`
+      return `${email}${fullName.trim() !== '' ? ` - ${fullName}` : ''}`
+    }
 
     const formatTitleTask = (requestedVisibility) => `Requests visibility set to "${requestedVisibility}"`
     const formatTitleItem = (title = '-') => title
@@ -57,7 +60,11 @@ function useDashboard() {
       return {
         date: formatDate(dateCreated),
         id,
-        initiator: formatInitator({ firstName: requestedBy.firstName, lastName: requestedBy.lastName }),
+        initiator: formatInitator({
+          email: requestedBy.email,
+          firstName: requestedBy.firstName,
+          lastName: requestedBy.lastName,
+        }),
         targetDocumentsIds: targetDoc.uid,
         itemType: formatItemType(targetDoc.type),
         isNew: targetDoc.isNew,

--- a/frontend/app/assets/javascripts/common/DataSource/useDashboard.js
+++ b/frontend/app/assets/javascripts/common/DataSource/useDashboard.js
@@ -78,10 +78,10 @@ function useDashboard() {
     // data easier in the FE. The following `friendlyNamePropertyNameLookup` converts
     // component names back to the server names
     const friendlyNamePropertyNameLookup = {
-      date: 'nt:dueDate',
+      date: 'dc:created',
       id: 'uid',
-      initiator: 'nt:initiator',
-      title: 'nt:name',
+      initiator: 'nt:initiator', // aka requested by person's email
+      titleTask: 'nt:directive', // aka requested visibility
     }
 
     return getSimpleTasks({

--- a/frontend/app/assets/javascripts/components/DashboardDetailTasks/DashboardDetailTasksData.js
+++ b/frontend/app/assets/javascripts/components/DashboardDetailTasks/DashboardDetailTasksData.js
@@ -251,10 +251,40 @@ function DashboardDetailTasksData({ children, columnRender }) {
   const onRowClick = (event, { id }) => {
     onOpen(id)
   }
-
-  const onOrderChange = () => {
+  const columns = [
+    {
+      title: '',
+      field: 'itemType',
+      render: columnRender.itemType,
+      sorting: false,
+      cellStyle,
+    },
+    {
+      title: 'Entry title',
+      field: 'titleItem',
+      sorting: false,
+      cellStyle,
+    },
+    {
+      title: 'Change requested',
+      field: 'titleTask',
+      cellStyle,
+    },
+    {
+      title: 'Requested by',
+      field: 'initiator',
+      cellStyle,
+    },
+    {
+      title: 'Date submitted',
+      field: 'date',
+      cellStyle,
+    },
+  ]
+  const onOrderChange = (index) => {
     navigate(
       getUrlDetailView({
+        sortBy: columns[index].field,
         sortOrder: querySortOrder === 'desc' ? 'asc' : 'desc',
         page: 1,
       })
@@ -263,35 +293,7 @@ function DashboardDetailTasksData({ children, columnRender }) {
 
   const cellStyle = selectn(['widget', 'cellStyle'], theme) || {}
   const childrenData = {
-    columns: [
-      {
-        title: '',
-        field: 'itemType',
-        render: columnRender.itemType,
-        sorting: false,
-        cellStyle,
-      },
-      {
-        title: 'Entry title',
-        field: 'titleItem',
-        cellStyle,
-      },
-      {
-        title: 'Change requested',
-        field: 'titleTask',
-        cellStyle,
-      },
-      {
-        title: 'Requested by',
-        field: 'initiator',
-        cellStyle,
-      },
-      {
-        title: 'Date submitted',
-        field: 'date',
-        cellStyle,
-      },
-    ],
+    columns: columns,
     // data: userId === 'Guest' ? [] : remoteData,
     data: tasks,
     idSelectedItem: queryItem,

--- a/frontend/app/assets/javascripts/components/WidgetTasks/WidgetTasksData.js
+++ b/frontend/app/assets/javascripts/components/WidgetTasks/WidgetTasksData.js
@@ -65,6 +65,7 @@ function WidgetTasksData({ children, columnRender }) {
         title: 'Entry title',
         field: 'titleItem',
         cellStyle,
+        sorting: false,
       },
       {
         title: 'Change requested',


### PR DESCRIPTION
- Disabled sort on `Entry title` column since it's a deeply nested prop that we can't sort against (at the moment)
- Dashboard Detail > Table view updates url on sort
- `useDashboard` update to set the correct data prop name when sorting