### PR TITLE
FW-1875 - Do not run Clean.Confusables after add confusables

### DIFF
--- a/FirstVoicesCharacters/src/main/java/ca/firstvoices/characters/workers/AddConfusablesWorker.java
+++ b/FirstVoicesCharacters/src/main/java/ca/firstvoices/characters/workers/AddConfusablesWorker.java
@@ -39,9 +39,6 @@ public class AddConfusablesWorker extends AbstractWork {
 
               // Remove job from required jobs
               RequiredJobsUtils.removeFromRequiredJobs(dialect, job, true);
-
-              // Add job to clean confusables to be picked up later
-              RequiredJobsUtils.addToRequiredJobs(dialect, Constants.CLEAN_CONFUSABLES_JOB_ID);
             });
   }
 


### PR DESCRIPTION
This process needs to be manual so that a user/superadmin can change the confusables before they are cleaned.