### PR TITLE
FW-1850 - remove tasks after changes to doc by non admins

### DIFF
--- a/FirstVoicesCoreIO/src/main/java/ca/firstvoices/core/io/utils/DialectUtils.java
+++ b/FirstVoicesCoreIO/src/main/java/ca/firstvoices/core/io/utils/DialectUtils.java
@@ -3,6 +3,7 @@ package ca.firstvoices.core.io.utils;
 import static ca.firstvoices.data.schemas.DomainTypesConstants.FV_DIALECT;
 
 import ca.firstvoices.data.exceptions.FVDocumentHierarchyException;
+import ca.firstvoices.data.schemas.DialectTypesConstants;
 import org.nuxeo.ecm.core.api.CoreInstance;
 import org.nuxeo.ecm.core.api.CoreSession;
 import org.nuxeo.ecm.core.api.DocumentModel;
@@ -49,6 +50,14 @@ public final class DialectUtils {
       }
       return dialect;
     }
+  }
+
+  /**
+   * Core
+   * @return true if the type is a core type
+   */
+  public static boolean isCoreType(String type) {
+    return DialectTypesConstants.getCoreTypes().contains(type);
   }
 
 }

--- a/FirstVoicesCoreIO/src/main/java/ca/firstvoices/core/io/utils/DocumentUtils.java
+++ b/FirstVoicesCoreIO/src/main/java/ca/firstvoices/core/io/utils/DocumentUtils.java
@@ -31,14 +31,18 @@ public final class DocumentUtils {
   }
 
   /**
-   * Checks if the document is an active workspace document Excludes proxies and versions (via
-   * isImmutable) and trashed docs. See https://doc.nuxeo.com/studio/filtering-options-reference-page/
-   * for why !isImmutable + !isProxy
-   *
-   * @param currentDoc
-   * @return
+   * Checks if the document is an active workspace document and non trashed docs
    */
   public static boolean isActiveDoc(DocumentModel currentDoc) {
-    return !currentDoc.isImmutable() && !currentDoc.isProxy() && !currentDoc.isTrashed();
+    return isMutable(currentDoc) && !currentDoc.isTrashed();
+  }
+
+  /**
+   * Checks if the document is an active workspace document excludes proxies and versions (via
+   * isImmutable). See https://doc.nuxeo.com/studio/filtering-options-reference-page/
+   * for why !isImmutable + !isProxy
+   */
+  public static boolean isMutable(DocumentModel currentDoc) {
+    return !currentDoc.isImmutable() && !currentDoc.isProxy();
   }
 }

--- a/FirstVoicesCoreIO/src/test/java/ca/firstvoices/core/io/utils/DialectUtilsTest.java
+++ b/FirstVoicesCoreIO/src/test/java/ca/firstvoices/core/io/utils/DialectUtilsTest.java
@@ -1,5 +1,6 @@
 package ca.firstvoices.core.io.utils;
 
+import ca.firstvoices.data.schemas.DialectTypesConstants;
 import ca.firstvoices.testUtil.AbstractTestDataCreatorTest;
 import ca.firstvoices.testUtil.annotations.TestDataConfiguration;
 import ca.firstvoices.tests.mocks.services.MockDialectService;
@@ -79,5 +80,12 @@ public class DialectUtilsTest extends AbstractTestDataCreatorTest {
   @Test
   public void getDialectWithSession() {
     Assert.assertEquals(dialect.getId(), DialectUtils.getDialect(session, dialect).getId());
+  }
+
+  @Test
+  public void isCoreType() {
+    Assert.assertTrue(DialectUtils.isCoreType(DialectTypesConstants.FV_WORD));
+    Assert.assertTrue(DialectUtils.isCoreType(DialectTypesConstants.FV_PHRASE));
+    Assert.assertTrue(DialectUtils.isCoreType(DialectTypesConstants.FV_BOOK));
   }
 }

--- a/FirstVoicesCoreTests/src/test/resources/test-data/test-language.yaml
+++ b/FirstVoicesCoreTests/src/test/resources/test-data/test-language.yaml
@@ -30,6 +30,7 @@ children:
             name: "Word"
             properties:
               part_of_speech: "noun"
+            key: testWord1
           - type: FVWord
             name: "Another Word"
             properties:

--- a/FirstVoicesData/src/main/java/ca/firstvoices/data/schemas/DialectTypesConstants.java
+++ b/FirstVoicesData/src/main/java/ca/firstvoices/data/schemas/DialectTypesConstants.java
@@ -1,5 +1,9 @@
 package ca.firstvoices.data.schemas;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * @author david
  */
@@ -47,6 +51,15 @@ public class DialectTypesConstants {
   public static final String FV_PORTAL = "FVPortal";
   public static final String FV_GALLERY = "FVGallery";
 
+  /**
+   * Core types make up most of the language data created by communities
+   * These are songs, story (FVBook), word or phrase
+   * @return the core types in FirstVoices
+   */
+  public static List<String> getCoreTypes() {
+    return new ArrayList<>(
+        Arrays.asList(FV_WORD, FV_PHRASE, FV_BOOK));
+  }
 
   private DialectTypesConstants() {
     throw new IllegalStateException("Utility class");

--- a/FirstVoicesMaintenance/src/main/java/ca/firstvoices/maintenance/listeners/PostCommitCleanupListener.java
+++ b/FirstVoicesMaintenance/src/main/java/ca/firstvoices/maintenance/listeners/PostCommitCleanupListener.java
@@ -1,0 +1,130 @@
+package ca.firstvoices.maintenance.listeners;
+
+import ca.firstvoices.core.io.utils.DialectUtils;
+import ca.firstvoices.core.io.utils.DocumentUtils;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.api.LifeCycleConstants;
+import org.nuxeo.ecm.core.api.event.DocumentEventTypes;
+import org.nuxeo.ecm.core.api.trash.TrashService;
+import org.nuxeo.ecm.core.event.Event;
+import org.nuxeo.ecm.core.event.EventBundle;
+import org.nuxeo.ecm.core.event.EventContext;
+import org.nuxeo.ecm.core.event.PostCommitEventListener;
+import org.nuxeo.ecm.core.event.impl.DocumentEventContext;
+import org.nuxeo.ecm.platform.query.api.PageProvider;
+import org.nuxeo.ecm.platform.query.api.PageProviderService;
+import org.nuxeo.ecm.platform.query.nxql.CoreQueryDocumentPageProvider;
+import org.nuxeo.runtime.api.Framework;
+
+
+/**
+ * This is a general listener for post commit, async cleanup operations
+ * Currently handled clearing tasks, but could be expanded to other uses or made abstract
+ */
+public class PostCommitCleanupListener implements PostCommitEventListener {
+
+  public static final String GET_ALL_OPEN_TASKS_FOR_DOCUMENT = "GET_ALL_OPEN_TASKS_FOR_DOCUMENT";
+
+  private ArrayList<String> endTaskEvents = new ArrayList<>();
+
+  @Override
+  public void handleEvent(EventBundle events) {
+    if (eventShouldBeHandled(events)) {
+      for (Event event : events) {
+        handleEvent(event);
+      }
+    }
+  }
+
+  /**
+   * Will handle individual events
+   *
+   * @param event the specific event to check against in the bundle
+   */
+  public void handleEvent(Event event) {
+    if (getEventsToHandle().contains(event.getName())) {
+      // Operations to execute for core types
+      EventContext ctx = event.getContext();
+
+      if (!ctx.getPrincipal().isAdministrator()
+          && ctx instanceof DocumentEventContext) {
+        // Only execute on non-admin events (system/FV), and when documents involved
+        DocumentEventContext docCtx = (DocumentEventContext) ctx;
+        DocumentModel doc = docCtx.getSourceDocument();
+
+        if (DocumentUtils.isMutable(doc)
+            && DialectUtils.isCoreType(doc.getType())) {
+          // For core types, end tasks if present
+          endRelatedTask(event, doc);
+        }
+      }
+    }
+  }
+
+  /**
+   * This is assessed when the event bundle is sent to the listener
+   *
+   * @return list of all events to handle; modify to handle more events.
+   */
+  private ArrayList<String> getEventsToHandle() {
+
+    // Events that trigger ending a task
+    endTaskEvents = new ArrayList<>();
+
+    endTaskEvents.add(DocumentEventTypes.DOCUMENT_UPDATED);
+    endTaskEvents.add(LifeCycleConstants.TRANSITION_EVENT);
+    endTaskEvents.add(TrashService.DOCUMENT_TRASHED);
+
+    return endTaskEvents;
+  }
+
+  /**
+   * Checks if the event bundle contains any of the events we want to handle
+   *
+   * @param events a collection of events fired
+   * @return true if event should be handled; false otherwise
+   */
+  private boolean eventShouldBeHandled(EventBundle events) {
+    return getEventsToHandle().stream().anyMatch((events::containsEventName));
+  }
+
+  /**
+   * Will "cancel" tasks that are related to the current document
+   * @param event the current event handled in the bundle
+   * @param coreTypeDoc the document to clear related tasks for
+   */
+  private void endRelatedTask(Event event, DocumentModel coreTypeDoc) {
+    if (endTaskEvents.contains(event.getName())) {
+      Map<String, Serializable> pageProviderProps = new HashMap<>();
+
+      // Core session to use with page provider
+      pageProviderProps.put(CoreQueryDocumentPageProvider.CORE_SESSION_PROPERTY,
+          (Serializable) event.getContext().getCoreSession());
+
+      // Use cache if available
+      pageProviderProps.put(CoreQueryDocumentPageProvider.CHECK_QUERY_CACHE_PROPERTY, true);
+
+      // Get all open tasks for the core type
+      PageProviderService pps = Framework.getService(PageProviderService.class);
+      PageProvider<?> pp = pps.getPageProvider(GET_ALL_OPEN_TASKS_FOR_DOCUMENT, null, null, 0L,
+          pageProviderProps, coreTypeDoc.getId());
+
+      @SuppressWarnings("unchecked")
+      List<DocumentModel> entries = (List<DocumentModel>) pp.getCurrentPage();
+      if (entries != null) {
+        for (DocumentModel task : entries) {
+          // Cancel task
+          String action = "cancel";
+          if (task.getAllowedStateTransitions().contains(action)) {
+            task.followTransition(action);
+          }
+        }
+      }
+    }
+  }
+}

--- a/FirstVoicesMaintenance/src/main/resources/OSGI-INF/maintenance/fv-maintenance-contrib.xml
+++ b/FirstVoicesMaintenance/src/main/resources/OSGI-INF/maintenance/fv-maintenance-contrib.xml
@@ -44,6 +44,17 @@
         </listener>
     </extension>
 
+    <!-- Listener will handle post commit, async cleanup events -->
+    <extension point="listener" target="org.nuxeo.ecm.core.event.EventServiceComponent">
+      <listener name="postCommitCleanupListener"
+        class="ca.firstvoices.maintenance.listeners.PostCommitCleanupListener"
+        async="true" postCommit="true" priority="350">
+        <event>documentModified</event>
+        <event>documentTrashed</event>
+        <event>lifecycle_transition_event</event>
+      </listener>
+    </extension>
+
     <!-- A work queue for handling maintenance tasks -->
     <extension point="queues" target="org.nuxeo.ecm.core.work.service">
         <queue id="fv-maintenance-requiredJobs">

--- a/FirstVoicesMaintenance/src/test/java/ca/firstvoices/maintenance/listeners/PostCommitCleanupListenerTest.java
+++ b/FirstVoicesMaintenance/src/test/java/ca/firstvoices/maintenance/listeners/PostCommitCleanupListenerTest.java
@@ -1,0 +1,208 @@
+package ca.firstvoices.maintenance.listeners;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import ca.firstvoices.testUtil.AbstractTestDataCreatorTest;
+import ca.firstvoices.testUtil.annotations.TestDataConfiguration;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import javax.inject.Inject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.nuxeo.ecm.automation.test.AutomationFeature;
+import org.nuxeo.ecm.core.api.CoreSession;
+import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.api.DocumentModelList;
+import org.nuxeo.ecm.core.api.IdRef;
+import org.nuxeo.ecm.core.api.event.DocumentEventTypes;
+import org.nuxeo.ecm.core.api.impl.DocumentModelImpl;
+import org.nuxeo.ecm.core.api.impl.DocumentModelListImpl;
+import org.nuxeo.ecm.core.event.EventContext;
+import org.nuxeo.ecm.core.event.EventService;
+import org.nuxeo.ecm.core.event.impl.DocumentEventContext;
+import org.nuxeo.ecm.core.test.CoreFeature;
+import org.nuxeo.ecm.core.test.annotations.Granularity;
+import org.nuxeo.ecm.core.test.annotations.RepositoryConfig;
+import org.nuxeo.ecm.platform.query.api.AbstractPageProvider;
+import org.nuxeo.ecm.platform.query.api.PageProviderService;
+import org.nuxeo.ecm.platform.usermanager.UserManager;
+import org.nuxeo.runtime.api.Framework;
+import org.nuxeo.runtime.mockito.MockitoFeature;
+import org.nuxeo.runtime.mockito.RuntimeService;
+import org.nuxeo.runtime.test.runner.Deploy;
+import org.nuxeo.runtime.test.runner.Features;
+import org.nuxeo.runtime.test.runner.FeaturesRunner;
+import org.nuxeo.runtime.transaction.TransactionHelper;
+
+@RunWith(FeaturesRunner.class)
+@Features({CoreFeature.class, AutomationFeature.class, MockitoFeature.class})
+@RepositoryConfig(cleanup = Granularity.METHOD)
+@Deploy({
+    "FirstVoicesMaintenance",
+    "FirstVoicesCoreTests:OSGI-INF/nuxeo.conf.override.xml"
+})
+@TestDataConfiguration(yaml = {"test-data/basic-structure.yaml", "test-data/test-language.yaml"})
+public class PostCommitCleanupListenerTest extends AbstractTestDataCreatorTest {
+
+  private static final String eventName = "postCommitCleanupListener";
+  // This is a fake task that would be returned by the page provider
+  MockDocumentModel fakeTask;
+  @Mock
+  @RuntimeService
+  PageProviderService pageProviderService;
+
+  @Inject
+  CoreSession session;
+
+  @Inject
+  EventService eventService;
+
+  @Inject
+  UserManager userManager;
+
+  DocumentModel word = null;
+
+  private static CoreSession getNonAdminCoreSession() {
+    CoreSession session = mock(CoreSession.class);
+    UserManager userManager = Framework.getService(UserManager.class);
+    when(session.getPrincipal()).thenReturn(userManager.getPrincipal("testUser"));
+    return session;
+  }
+
+  @Before
+  public void setUp() {
+    assertNotNull("Post commit cleanup listener registered",
+        eventService.getEventListener(eventName));
+    word = session.getDocument(new IdRef(this.dataCreator.getReference("testWord1")));
+
+    // Create a regular user
+    DocumentModel userModel = userManager.getBareUserModel();
+    String schemaName = userManager.getUserSchemaName();
+    userModel.setProperty(schemaName, "username", "testUser");
+    userManager.createUser(userModel);
+    session.save();
+
+    // Return a fake page provider defined above instead of the actual page provider
+    // Note: Need to use DoReturn for generics
+    // See: https://dzone.com/articles/mocking-method-with-wildcard-generic-return-type
+    doReturn(new FakePageProvider<DocumentModelList>()).when(pageProviderService)
+        .getPageProvider(eq(PostCommitCleanupListener.GET_ALL_OPEN_TASKS_FOR_DOCUMENT), eq(null),
+            eq(null), anyLong(), any(), eq(word.getId()));
+
+    fakeTask = new MockDocumentModel("TaskDoc");
+  }
+
+  @Test
+  public void shouldHandleNonAdminEvent() {
+    // Ensure transition starts off as not run
+    assertFalse(fakeTask.transitionRan);
+
+    // Fire event as non-system admin user
+    EventContext ctx = new DocumentEventContext(getNonAdminCoreSession(),
+        getNonAdminCoreSession().getPrincipal(), word);
+    eventService.fireEvent(ctx.newEvent(DocumentEventTypes.DOCUMENT_UPDATED));
+
+    // Commit and wait for event to complete
+    TransactionHelper.commitOrRollbackTransaction();
+    eventService.waitForAsyncCompletion();
+
+    // Ensure transition ran
+    assertTrue(fakeTask.transitionRan);
+  }
+
+  @Test
+  public void shouldNotHandleNonCoreTypeEvent() {
+    // Ensure transition starts off as not run
+    assertFalse(fakeTask.transitionRan);
+
+    // Fire event as non-system admin user on dialect
+    DocumentModel dialect = session
+        .getDocument(new IdRef(this.dataCreator.getReference("testArchive")));
+
+    EventContext ctx = new DocumentEventContext(session, session.getPrincipal(), dialect);
+    eventService.fireEvent(ctx.newEvent(DocumentEventTypes.DOCUMENT_UPDATED));
+
+    // Commit and wait for event to complete
+    TransactionHelper.commitOrRollbackTransaction();
+    eventService.waitForAsyncCompletion();
+
+    // Ensure transition is still not run
+    assertFalse(fakeTask.transitionRan);
+  }
+
+  @Test
+  public void shouldNotHandleAdminEvent() {
+    // Ensure transition starts off as not run
+    assertFalse(fakeTask.transitionRan);
+
+    // Fire event as non-system admin user
+    EventContext ctx = new DocumentEventContext(session, session.getPrincipal(), word);
+    eventService.fireEvent(ctx.newEvent(DocumentEventTypes.DOCUMENT_UPDATED));
+
+    // Commit and wait for event to complete
+    TransactionHelper.commitOrRollbackTransaction();
+    eventService.waitForAsyncCompletion();
+
+    // Ensure transition is still not run
+    assertFalse(fakeTask.transitionRan);
+  }
+
+  /**
+   * Fake document model to mimic transitions
+   */
+  public static class MockDocumentModel extends DocumentModelImpl {
+
+    private static final long serialVersionUID = 1L;
+    protected String uid;
+    protected boolean transitionRan;
+
+    public MockDocumentModel(String uid) {
+      this.uid = uid;
+      this.transitionRan = false;
+    }
+
+    @Override
+    public boolean followTransition(final String transition) {
+      transitionRan = true;
+      return true;
+    }
+
+    @Override
+    public Collection<String> getAllowedStateTransitions() {
+      return Collections.singletonList("cancel");
+    }
+  }
+
+  /**
+   * Fake page provider to mimic `GET_ALL_OPEN_TASKS_FOR_DOCUMENT`
+   *
+   * @param <T>
+   */
+  public class FakePageProvider<T extends Serializable> extends AbstractPageProvider<T> {
+
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public List<T> getCurrentPage() {
+      DocumentModelList list = new DocumentModelListImpl();
+      list.add(fakeTask);
+
+      return (List<T>) list;
+    }
+
+  }
+
+}

--- a/FirstVoicesRESTPageProviders/src/main/resources/OSGI-INF/extensions/ca.firstvoices.pageproviders.tasks.xml
+++ b/FirstVoicesRESTPageProviders/src/main/resources/OSGI-INF/extensions/ca.firstvoices.pageproviders.tasks.xml
@@ -6,7 +6,6 @@
 
     <extension target="org.nuxeo.ecm.platform.query.api.PageProviderService"
                point="providers">
-
         <coreQueryPageProvider name="GET_NON_DELEGATED_TASKS_FOR_ACTORS">
             <pattern>
               SELECT * FROM Document WHERE ecm:mixinType = 'Task' AND
@@ -18,5 +17,16 @@
             <pageSize>0</pageSize>
             <maxPageSize>0</maxPageSize>
         </coreQueryPageProvider>
+
+        <coreQueryPageProvider name="GET_ALL_OPEN_TASKS_FOR_DOCUMENT">
+          <pattern>
+            SELECT * FROM Document WHERE ecm:mixinType = 'Task'
+            AND ecm:currentLifeCycleState NOT IN ('ended', 'cancelled')
+            AND nt:targetDocumentsIds/* = ?
+            AND ecm:isProxy = 0 AND ecm:isVersion = 0
+          </pattern>
+          <pageSize>20</pageSize>
+        </coreQueryPageProvider>
+
     </extension>
 </component>


### PR DESCRIPTION
Made some slight changes to FVCore, FVData.

Opted to put this logic in FVMaintenance so that we can use this for future post commit, async cleanup events that need to happen after a doc is committed. Alternatively this could like in an FVTasks package if we create one.