### PR TITLE
FW-1896 Bug fix - not saving emptied form fields

### DIFF
--- a/frontend/app/assets/javascripts/views/hoc/view/with-form.js
+++ b/frontend/app/assets/javascripts/views/hoc/view/with-form.js
@@ -70,7 +70,7 @@ export default function withForm(ComposedFilter /*, publishWarningEnabled = fals
             // NOTE: we can encounter checkboxes that have formValue[key] === false.
             // If we just used `if (formValue[key])` in the following conditional,
             // we'd toss out unselected checkboxes
-            if (formValue[key] !== null && formValue[key] !== undefined && formValue[key] !== '') {
+            if (formValue[key] !== undefined && formValue[key] !== '') {
               // Filter out null values in an array
               if (formValue[key] instanceof Array) {
                 const formValueKey = formValue[key].filter((item) => item !== null)


### PR DESCRIPTION
Edit form was not saving empty fields, so for example, if a user added pronunciation to a word, they could subsequently update the pronunciation but they couldn't delete it entirely.

NB: `getValue()` on tcomb-form is returning `null` values for string fields that are submitted as empty

Removed `null` filtering logic for non-list form values in _onRequestSaveForm function