### PR TITLE
FW-1917 - Use actual user's name in email

### DIFF
--- a/FirstVoicesCoreIO/src/main/resources/OSGI-INF/ca.firstvoices.notifications.xml
+++ b/FirstVoicesCoreIO/src/main/resources/OSGI-INF/ca.firstvoices.notifications.xml
@@ -17,7 +17,7 @@
     <notification enabled="false" name="Workflow Change"/>
 
     <notification autoSubscribed="true" availableIn="Workspace" channel="email" enabled="true"
-      label="test" name="Task delegated" subject="${author} requested changes for ${docTitle}"
+      label="test" name="Task delegated" subject="Changes requested for ${docTitle}"
       template="changesRequested">
       <event name="workflowTaskDelegated"/>
     </notification>

--- a/FirstVoicesCoreIO/src/main/resources/data/templates/changesRequested.ftl
+++ b/FirstVoicesCoreIO/src/main/resources/data/templates/changesRequested.ftl
@@ -9,7 +9,7 @@
     -->
 
     <p>
-      <strong>${author}</strong>
+      <strong>${comment?keep_after("Task delegated by '")?keep_before("' to")}</strong>
       has requested changes for
       <#if document.type == "FVWord">
       the word

--- a/FirstVoicesCoreIO/src/main/resources/data/templates/changesRequested.ftl
+++ b/FirstVoicesCoreIO/src/main/resources/data/templates/changesRequested.ftl
@@ -1,3 +1,6 @@
+<#assign extractedComment = comment?keep_after("with the following comment:")>
+<#assign siteUrl = Runtime.getProperty('nuxeo.url')?keep_before(Runtime.getProperty('org.nuxeo.ecm.contextPath'))>
+
 <html>
   <body>
     <#--
@@ -15,7 +18,7 @@
       the word
       <strong>
         <a
-          href="${Runtime.getProperty('nuxeo.url')}/explore${document.path?keep_before('Dictionary')}/learn/words/${docId}">
+          href="${siteUrl}/explore${document.path?keep_before('/Dictionary')}/learn/words/${docId}">
           ${htmlEscape(docTitle)}
         </a>
       </strong>
@@ -23,7 +26,7 @@
       the phrase
       <strong>
         <a
-          href="${Runtime.getProperty('nuxeo.url')}/explore${document.path?keep_before('Dictionary')}/learn/phrases/${docId}">
+          href="${siteUrl}/explore${document.path?keep_before('/Dictionary')}/learn/phrases/${docId}">
           ${htmlEscape(docTitle)}
         </a>
       </strong>
@@ -32,7 +35,7 @@
       <#assign pluralType = (document.fvbook.type == "song")?then("songs","stories")>
       <strong>
         <a
-          href="${Runtime.getProperty('nuxeo.url')}/explore${document.path?keep_before('Songs')}/learn/phrases/${docId}">
+          href="${siteUrl}/explore${document.path?keep_before('/Songs')}/learn/{pluralType}/${docId}">
           ${htmlEscape(docTitle)}
         </a>
       </strong>
@@ -46,7 +49,6 @@
     <br/>
   </p>
 
-  <#assign extractedComment = comment?keep_after("with the following comment:")>
   <blockquote>${htmlEscape(extractedComment)}</blockquote>
 
   <p>


### PR DESCRIPTION
Extracting from comment due to bug with CurrentUser

(see note here: https://doc.nuxeo.com/studio/available-variables-in-email-templates/ -> `${CurrentUser} is not correctly working for now in FTL templates. However, if your email template is sent in the context of an automation chain or script, it is possible to use a workaround by defining its value in a context variable`)