### PR TITLE
FW-2001 - Publishing fixes

### DIFF
--- a/FirstVoicesCoreIO/src/test/java/ca/firstvoices/core/io/utils/DocumentUtilsTest.java
+++ b/FirstVoicesCoreIO/src/test/java/ca/firstvoices/core/io/utils/DocumentUtilsTest.java
@@ -1,0 +1,97 @@
+package ca.firstvoices.core.io.utils;
+
+import static ca.firstvoices.data.schemas.DomainTypesConstants.FV_LANGUAGE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import ca.firstvoices.testUtil.AbstractTestDataCreatorTest;
+import ca.firstvoices.testUtil.annotations.TestDataConfiguration;
+import java.util.List;
+import javax.inject.Inject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.nuxeo.ecm.core.api.CoreSession;
+import org.nuxeo.ecm.core.api.DocumentModel;
+import org.nuxeo.ecm.core.api.DocumentModelList;
+import org.nuxeo.ecm.core.api.trash.TrashService;
+import org.nuxeo.ecm.core.test.DefaultRepositoryInit;
+import org.nuxeo.ecm.core.test.annotations.Granularity;
+import org.nuxeo.ecm.core.test.annotations.RepositoryConfig;
+import org.nuxeo.ecm.platform.test.PlatformFeature;
+import org.nuxeo.runtime.test.runner.Features;
+import org.nuxeo.runtime.test.runner.FeaturesRunner;
+
+@RunWith(FeaturesRunner.class)
+@Features({PlatformFeature.class})
+@RepositoryConfig(init = DefaultRepositoryInit.class, cleanup = Granularity.CLASS)
+@TestDataConfiguration(yaml = {"test-data/basic-structure.yaml", "test-data/test-language.yaml"})
+public class DocumentUtilsTest extends AbstractTestDataCreatorTest {
+
+  @Inject
+  CoreSession session;
+
+  @Inject
+  TrashService trashService;
+
+  DocumentModel dialect = null;
+
+  @Before
+  public void setUp() {
+    dialect = dataCreator.getReference(session, "testArchive");
+  }
+
+  @After
+  public void tearDown() {
+    DocumentModelList docs = session.query("SELECT * FROM Document WHERE ecm:isProxy = 0 AND ecm:isVersion = 0");
+
+    for (DocumentModel doc : docs) {
+      if (session.exists(doc.getRef())) {
+        session.removeDocument(doc.getRef());
+      }
+    }
+  }
+
+  @Test
+  public void shouldGetParentDoc() {
+    DocumentModel language = DocumentUtils.getParentDoc(session, dialect, FV_LANGUAGE);
+    assertEquals(dataCreator.getReference(session, "testLanguage").getId(), language.getId());
+  }
+
+  @Test
+  public void shouldBeActiveDoc() {
+    // Test workspace dialect
+    assertTrue(DocumentUtils.isActiveDoc(dialect));
+  }
+
+  @Test
+  public void shouldNotBeActiveDoc() {
+    // Test versions of dialect
+    List<DocumentModel> versions = session.getVersions(dialect.getRef());
+    assertFalse(DocumentUtils.isActiveDoc(versions.get(0)));
+
+    // Test proxy
+    DocumentModelList proxies = session.getProxies(dialect.getRef(), null);
+    assertFalse(DocumentUtils.isActiveDoc(proxies.get(0)));
+
+    // Test trashed workspace dialect
+    trashService.trashDocument(dialect);
+    assertFalse(DocumentUtils.isActiveDoc(dialect));
+  }
+
+  @Test
+  public void shouldBeMutable() {
+    assertTrue(DocumentUtils.isMutable(dialect));
+  }
+
+  @Test
+  public void shouldNotBeMutable() {
+    List<DocumentModel> versions = session.getVersions(dialect.getRef());
+    assertFalse(DocumentUtils.isMutable(versions.get(0)));
+
+    List<DocumentModel> proxies = session.getProxies(dialect.getRef(), null);
+    assertFalse(DocumentUtils.isMutable(proxies.get(0)));
+  }
+}

--- a/FirstVoicesData/src/main/java/ca/firstvoices/data/schemas/DomainTypesConstants.java
+++ b/FirstVoicesData/src/main/java/ca/firstvoices/data/schemas/DomainTypesConstants.java
@@ -9,6 +9,8 @@ public class DomainTypesConstants {
   public static final String FV_LANGUAGE_FAMILY = "FVLanguageFamily";
   public static final String FV_DIALECT = "FVDialect";
 
+  public static final String FV_SHARED_DATA_NAME = "SharedData";
+
   private DomainTypesConstants() {
     throw new IllegalStateException("Utility class");
   }

--- a/FirstVoicesMaintenance/src/main/java/ca/firstvoices/maintenance/listeners/ExecuteRequiredJobsListener.java
+++ b/FirstVoicesMaintenance/src/main/java/ca/firstvoices/maintenance/listeners/ExecuteRequiredJobsListener.java
@@ -116,7 +116,7 @@ public class ExecuteRequiredJobsListener implements EventListener {
                     event.markBubbleException();
                     log.severe(
                         () -> "Failed when trying to execute required jobs with message: " + e
-                            .getMessage());
+                            .getMessage() + " on dialect " + dialect.getId());
                   }
                 }
               }

--- a/FirstVoicesPublisher/src/main/java/ca/firstvoices/publisher/listeners/ProxyPublisherListener.java
+++ b/FirstVoicesPublisher/src/main/java/ca/firstvoices/publisher/listeners/ProxyPublisherListener.java
@@ -82,8 +82,8 @@ public class ProxyPublisherListener implements PostCommitEventListener {
     String transition = (String) ctx.getProperties().get(TRANSTION_EVENT_OPTION_TRANSITION);
     String transitionFrom = (String) ctx.getProperties().get(TRANSTION_EVENT_OPTION_FROM);
 
-    if (DocumentUtils.isMutable(doc) && isDialectBusyOrUnavailable(doc)) {
-      // Do not trigger listener for immutable documents and while dialect publishing
+    if (!DocumentUtils.isMutable(doc) || isDialectBusyOrUnavailable(doc)) {
+      // Do not trigger listener for immutable documents or while dialect publishing
       // is pending since the creation of proxies is done via `CreateProxiesWorker`
       return;
     }

--- a/FirstVoicesPublisher/src/main/java/ca/firstvoices/publisher/services/FirstVoicesPublisherServiceImpl.java
+++ b/FirstVoicesPublisher/src/main/java/ca/firstvoices/publisher/services/FirstVoicesPublisherServiceImpl.java
@@ -40,6 +40,7 @@ import static ca.firstvoices.data.schemas.DialectTypesConstants.FV_PORTAL_NAME;
 import static ca.firstvoices.data.schemas.DialectTypesConstants.FV_VIDEO;
 import static ca.firstvoices.data.schemas.DialectTypesConstants.FV_WORD;
 import static ca.firstvoices.data.schemas.DomainTypesConstants.FV_DIALECT;
+import static ca.firstvoices.data.schemas.DomainTypesConstants.FV_SHARED_DATA_NAME;
 
 import ca.firstvoices.core.io.services.TransitionChildrenStateService;
 import ca.firstvoices.core.io.utils.DialectUtils;
@@ -57,6 +58,7 @@ import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.nuxeo.ecm.core.api.AbstractSession;
 import org.nuxeo.ecm.core.api.CoreSession;
 import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.DocumentModelList;
@@ -67,6 +69,7 @@ import org.nuxeo.ecm.core.api.PropertyException;
 import org.nuxeo.ecm.core.api.impl.DocumentModelListImpl;
 import org.nuxeo.ecm.core.api.model.Property;
 import org.nuxeo.ecm.core.lifecycle.LifeCycleService;
+import org.nuxeo.ecm.core.model.Document;
 import org.nuxeo.ecm.platform.publisher.api.PublisherService;
 import org.nuxeo.runtime.api.Framework;
 
@@ -196,6 +199,13 @@ public class FirstVoicesPublisherServiceImpl implements FirstVoicesPublisherServ
 
     DocumentModelList publishedDocs = new DocumentModelListImpl();
 
+    // Update state from REPUBLISH->PUBLISH directly on a low-level doc
+    // Will avoid going through life-cycle service and triggering
+    // additional listener event. Proxy will have PUBLISH state too
+    Document lowLevelDoc =
+        ((AbstractSession) session).getSession().getDocumentByUUID(doc.getId());
+    lowLevelDoc.setCurrentLifeCycleState(PUBLISHED_STATE);
+
     if (isPublishableAsset(doc.getType())) {
       publishedDocs.add(createProxyForAsset(doc));
     } else if (isDialect) {
@@ -206,19 +216,10 @@ public class FirstVoicesPublisherServiceImpl implements FirstVoicesPublisherServ
       publishedDocs.add(createProxyForDialect(doc));
     }
 
-    // After republish move back to publish state if applicable
-    // If doRepublish is called directly, no transition is required
-    StateUtils.followTransitionIfAllowed(doc, PUBLISH_TRANSITION);
-
     if (publishedDocs.isEmpty() || publishedDocs.contains(null)) {
       log.error(String.format(
           "Republishing (overwriting proxy) not successful on doc %s (%s)",
           doc.getTitle(), doc.getId()));
-    } else {
-      for (DocumentModel publishedDoc : publishedDocs) {
-        // Also follow transition for each proxy so the state is set back to PUBLISH
-        StateUtils.followTransitionIfAllowed(publishedDoc, PUBLISH_TRANSITION);
-      }
     }
   }
 
@@ -442,10 +443,9 @@ public class FirstVoicesPublisherServiceImpl implements FirstVoicesPublisherServ
             DocumentModel dependencyDoc = session.getDocument(dependencyRef);
 
             if (dependenciesToSkipPublishing.contains(workspaceFieldName)
-                || dependencyDoc.getPathAsString().contains("SharedData")) {
-              // Origin field: should be grabbed if it is published
-              // SharedData dependencies (e.g. Shared Links): should get publication
-              // Both should NOT be automatically published
+                || dependencyDoc.getPathAsString().contains(FV_SHARED_DATA_NAME)) {
+              // Do not attempt to publish origin field or SharedData dependencies
+              // (e.g. Shared Links): both should get publication if available
               newProxy = getPublication(session, dependencyRef);
             } else {
               // Publish dependency (overwriting if needed)

--- a/FirstVoicesPublisher/src/main/java/ca/firstvoices/publisher/services/FirstVoicesPublisherServiceImpl.java
+++ b/FirstVoicesPublisher/src/main/java/ca/firstvoices/publisher/services/FirstVoicesPublisherServiceImpl.java
@@ -439,14 +439,18 @@ public class FirstVoicesPublisherServiceImpl implements FirstVoicesPublisherServ
               continue;
             }
 
-            if (dependenciesToSkipPublishing.contains(workspaceFieldName)) {
-              // Origin field should be grabbed if it is published
-              // Should not be automatically published
+            DocumentModel dependencyDoc = session.getDocument(dependencyRef);
+
+            if (dependenciesToSkipPublishing.contains(workspaceFieldName)
+                || dependencyDoc.getPathAsString().contains("SharedData")) {
+              // Origin field: should be grabbed if it is published
+              // SharedData dependencies (e.g. Shared Links): should get publication
+              // Both should NOT be automatically published
               newProxy = getPublication(session, dependencyRef);
             } else {
               // Publish dependency (overwriting if needed)
               newProxy =
-                  transitionAndCreateProxy(session, session.getDocument(dependencyRef));
+                  transitionAndCreateProxy(session, dependencyDoc);
             }
 
             if (newProxy != null && !newProxyValues.contains(newProxy.getId())) {

--- a/FirstVoicesPublisher/src/test/java/ca/firstvoices/services/PublisherServiceTest.java
+++ b/FirstVoicesPublisher/src/test/java/ca/firstvoices/services/PublisherServiceTest.java
@@ -13,6 +13,7 @@ import static ca.firstvoices.data.schemas.DialectTypesConstants.FV_CATEGORY;
 import static ca.firstvoices.data.schemas.DialectTypesConstants.FV_CHARACTER;
 import static ca.firstvoices.data.schemas.DialectTypesConstants.FV_CONTRIBUTOR;
 import static ca.firstvoices.data.schemas.DialectTypesConstants.FV_LINK;
+import static ca.firstvoices.data.schemas.DialectTypesConstants.FV_LINKS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -33,7 +34,6 @@ import org.junit.runner.RunWith;
 import org.nuxeo.ecm.core.api.CoreSession;
 import org.nuxeo.ecm.core.api.DocumentModel;
 import org.nuxeo.ecm.core.api.DocumentModelList;
-import org.nuxeo.ecm.core.api.IdRef;
 import org.nuxeo.ecm.core.api.impl.DocumentModelListImpl;
 import org.nuxeo.ecm.core.event.EventService;
 import org.nuxeo.ecm.core.event.impl.EventListenerDescriptor;
@@ -187,9 +187,17 @@ public class PublisherServiceTest extends AbstractTestDataCreatorTest {
     shouldTransitionDialectToPublish();
 
     // Create links
-    DocumentModelList links = createLinks(2);
+    DocumentModelList links = createLinks(2, false);
 
-    dialect.setPropertyValue("fvdialect:keyboards", new String[]{links.get(0).getId()});
+    // Create one shared link, and publish
+    DocumentModelList sharedLinks = createLinks(1, true);
+    DocumentModel sharedLink = sharedLinks.get(0);
+
+    // Publish shared link (doesn't have to be in SharedLinks for test)
+    sharedLink.followTransition(PUBLISH_TRANSITION);
+    session.publishDocument(sharedLink, dataCreator.getReference(session, "sectionsData"), true);
+
+    dialect.setPropertyValue("fvdialect:keyboards", new String[]{links.get(0).getId(), sharedLink.getId()});
     dialect.setPropertyValue("fvdialect:language_resources", new String[]{links.get(1).getId()});
 
     session.saveDocument(dialect);
@@ -235,7 +243,7 @@ public class PublisherServiceTest extends AbstractTestDataCreatorTest {
     // Other fields should follow similar logic: fv-portal:background_top_image,
     //fv-portal:featured_audio
     // fv-portal:logo,
-    DocumentModelList links = createLinks(1);
+    DocumentModelList links = createLinks(1, false);
 
     portal.setPropertyValue("fv-portal:featured_words",
         new String[]{words.get(0).getId(), words.get(2).getId()});
@@ -360,7 +368,7 @@ public class PublisherServiceTest extends AbstractTestDataCreatorTest {
         PropertyUtils.getValuesAsList(dialectProxy, "fvproxy:proxied_keyboards").size());
 
     // Add 1 more link
-    DocumentModelList links = createLinks(2);
+    DocumentModelList links = createLinks(2, false);
     dialect.setPropertyValue("fvdialect:keyboards",
         new String[]{links.get(0).getId(), links.get(1).getId()});
 
@@ -519,12 +527,22 @@ public class PublisherServiceTest extends AbstractTestDataCreatorTest {
         state));
   }
 
-  private DocumentModelList createLinks(int max) {
+  private DocumentModelList createLinks(int max, boolean shared) {
     DocumentModelList links = new DocumentModelListImpl();
+
+    String parentLinksPath = dialect.getPathAsString() + "/Links";
+
+    if (shared) {
+      DocumentModel sharedLinksParent =
+          session.createDocumentModel("/FV/Workspaces/SharedData/", "Shared Links", FV_LINKS);
+      sharedLinksParent = session.createDocument(sharedLinksParent);
+
+      parentLinksPath = sharedLinksParent.getPathAsString();
+    }
 
     for (int i = 0; i <= max; ++i) {
       DocumentModel link =
-          session.createDocumentModel(dialect.getPathAsString() + "/Links", "Link" + i, FV_LINK);
+          session.createDocumentModel(parentLinksPath, "Link" + i, FV_LINK);
       links.add(session.createDocument(link));
     }
 

--- a/FirstVoicesPublisher/src/test/java/ca/firstvoices/services/PublisherServiceTest.java
+++ b/FirstVoicesPublisher/src/test/java/ca/firstvoices/services/PublisherServiceTest.java
@@ -17,6 +17,7 @@ import static ca.firstvoices.data.schemas.DialectTypesConstants.FV_LINKS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import ca.firstvoices.core.io.utils.PropertyUtils;
 import ca.firstvoices.publisher.services.FirstVoicesPublisherService;
@@ -220,10 +221,10 @@ public class PublisherServiceTest extends AbstractTestDataCreatorTest {
     assertNotNull(linksProxy);
 
     // Test proxy fields for dialect
-    assertEquals(link1Proxy.getId(),
-        PropertyUtils.getValuesAsList(dialectProxy, "fvproxy:proxied_keyboards").get(0));
-    assertEquals(link2Proxy.getId(),
-        PropertyUtils.getValuesAsList(dialectProxy, "fvproxy:proxied_language_resources").get(0));
+    assertTrue(PropertyUtils.getValuesAsList(dialectProxy, "fvproxy:proxied_keyboards")
+        .contains(link1Proxy.getId()));
+    assertTrue(PropertyUtils.getValuesAsList(dialectProxy, "fvproxy:proxied_language_resources")
+        .contains(link2Proxy.getId()));
   }
 
   @Test
@@ -364,7 +365,7 @@ public class PublisherServiceTest extends AbstractTestDataCreatorTest {
     DocumentModel dialectProxy = fvPublisherService.getPublication(session, dialect.getRef());
     assertNotNull(dialectProxy);
 
-    assertEquals(1,
+    assertEquals(2,
         PropertyUtils.getValuesAsList(dialectProxy, "fvproxy:proxied_keyboards").size());
 
     // Add 1 more link


### PR DESCRIPTION
Issues resolved:

- Listener was triggering for proxies, as well as workspaces (wrong condition in ProxyPublisherListener), although it most likely did not affect functionality, it would have produced some error in log files
- Dialects can reference shared links (from SharedData) in Keyboards/language resources - this was the main reason for publishing not working in Production, which we didn't catch in Dev/Preprod
- Optimization (and possible solution for things stuck in Republish): the republish end-point will always explicitly set the document to publish bypassing the lifecycle service, and thus not triggering an additional event.
