### PR TITLE
FW-2015, FW-2070, FW-2063 - various explore language / state bugs

### DIFF
--- a/modules/api/firstvoices-rest-api/src/main/java/org/nuxeo/ecm/restapi/server/jaxrs/firstvoices/SitesObject.java
+++ b/modules/api/firstvoices-rest-api/src/main/java/org/nuxeo/ecm/restapi/server/jaxrs/firstvoices/SitesObject.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
@@ -205,9 +206,6 @@ public class SitesObject extends DefaultObject {
         } else {
           associatedDialect = session.getDocument(new IdRef((String) dm.getProperty("fvancestry",
               "dialect")));
-          associatedLanguageFamily = session.getDocument(new IdRef((String) dm.getProperty(
-              "fvancestry",
-              "family")));
           logoImageId = (String) dm.getProperty("fv-portal", "logo");
         }
 
@@ -241,7 +239,7 @@ public class SitesObject extends DefaultObject {
           return null;
         }
 
-      }).filter(d -> d != null).collect(Collectors.toList());
+      }).filter(Objects::nonNull).collect(Collectors.toList());
       SiteList mappedResults = new SiteList(sites);
 
       Response.ResponseBuilder responseBuilder = Response.ok().entity(mappedResults).cacheControl(

--- a/modules/common/firstvoices-data/src/main/resources/OSGI-INF/dialect/dialect-contrib.xml
+++ b/modules/common/firstvoices-data/src/main/resources/OSGI-INF/dialect/dialect-contrib.xml
@@ -67,7 +67,7 @@
   <extension target="org.nuxeo.ecm.core.lifecycle.LifeCycleService" point="types">
     <types>
       <!-- Disable some recursive transitions, see org.nuxeo.ecm.core.lifecycle.event -> BulkLifeCycleChangeListener-->
-      <type name="FVDialect" noRecursionForTransitions="Enable,Disable,Publish,Republish,RevertToNew,Unpublish">fv-lifecycle</type>
+      <type name="FVDialect" noRecursionForTransitions="Publish,Republish,Unpublish">fv-lifecycle</type>
     </types>
   </extension>
 

--- a/modules/common/firstvoices-data/src/main/resources/data/schemas/fvmedia.xsd
+++ b/modules/common/firstvoices-data/src/main/resources/data/schemas/fvmedia.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:nxs="http://www.nuxeo.org/ecm/project/schemas/First-Voices/fvmedia" xmlns:nxsv="http://www.nuxeo.org/ecm/schemas/core/validation/" xmlns:ref="http://www.nuxeo.org/ecm/schemas/core/external-references/" targetNamespace="http://www.nuxeo.org/ecm/project/schemas/First-Voices/fvmedia">  
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:nxs="http://www.nuxeo.org/ecm/project/schemas/First-Voices/fvmedia" targetNamespace="http://www.nuxeo.org/ecm/project/schemas/First-Voices/fvmedia">
   <!-- helper XSD definitions for list types -->  
   <xs:complexType name="content"> 
     <xs:sequence> 
@@ -33,10 +33,18 @@
     </xs:sequence> 
   </xs:complexType>  
   <xs:element name="acknowledgement" type="xs:string"/>
-  <xs:element name="child_focused" type="xs:boolean" default="false"/>
+
+  <!--
+    FW-2015: Remove default="false" as we use this schema on proxies
+    and the system seems to attempt to set `false` on update, resulting
+    in a `cannot set property on proxy` error
+    See also https://jira.nuxeo.com/browse/NXP-19466
+   -->
+  <xs:element name="child_focused" type="xs:boolean" />
+  <xs:element name="shared" type="xs:boolean" />
+
   <xs:element name="copyright" type="xs:string"/>
   <xs:element name="origin" type="xs:string"/>
   <xs:element name="recorder" type="nxs:stringList"/>
-  <xs:element name="shared" type="xs:boolean" default="false"/>
   <xs:element name="source" type="nxs:stringList"/>
 </xs:schema>

--- a/modules/common/firstvoices-data/src/main/resources/data/schemas/fvpage.xsd
+++ b/modules/common/firstvoices-data/src/main/resources/data/schemas/fvpage.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:nxs="http://www.nuxeo.org/ecm/project/schemas/First-Voices/fvpage" xmlns:nxsv="http://www.nuxeo.org/ecm/schemas/core/validation/" xmlns:ref="http://www.nuxeo.org/ecm/schemas/core/external-references/" targetNamespace="http://www.nuxeo.org/ecm/project/schemas/First-Voices/fvpage">  
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:nxs="http://www.nuxeo.org/ecm/project/schemas/First-Voices/fvpage" targetNamespace="http://www.nuxeo.org/ecm/project/schemas/First-Voices/fvpage">
   <!-- helper XSD definitions for list types -->  
   <xs:complexType name="content"> 
     <xs:sequence> 
@@ -47,6 +47,6 @@
       <xs:element name="summary" type="xs:string"/>
     </xs:sequence>
   </xs:complexType>
-  <xs:element name="primary_navigation" type="xs:boolean" default="false"/>
+  <xs:element name="primary_navigation" type="xs:boolean" />
   <xs:element name="url" type="xs:string"/>
 </xs:schema>


### PR DESCRIPTION
FW-2015 - Remove default="false" from fvm:child_focused. Does not seem to have any side effects. Since we use this schema on proxies, and the system seems to attempt to set `false` on update, publishing results in a `cannot set property on proxy` error. See also https://jira.nuxeo.com/browse/NXP-19466

FW-2070 - Ensure Enable, Disable, and RevertToNew apply to children when changing a dialect (caused issues with members not seeing their dialect)

FW-2063 - Workspaces query does not need language family title (explore language). Caused issues by non-super admins trying to access the language object which they do not have permission for.

#### Definition of Done
- [ ] Reviewer can follow the flow of the code
- [ ] Variables, methods are named properly and clearly
- [ ] Methods are documented using comments (where not self-explanatory)
- [ ] Any suggestions for refactoring have been implemented
- [ ] Tests are created and cover at least 85% of the functionality
- [ ] Code is unlikely to introduce new regressions
- [ ] Acceptance criteria has been met
