### PR TITLE
FW-1808 - Fix registration test; allow retries

### DIFF
--- a/frontend/app/common/locale/locale.en.json
+++ b/frontend/app/common/locale/locale.en.json
@@ -706,7 +706,7 @@
     "redirecting": "Redirecting",
     "reference": "Reference",
     "region": "region",
-    "register": "register",
+    "register": "Register",
     "registration": "registration",
     "reject": "Reject",
     "related": "related",

--- a/frontend/app/components/Register/index.js
+++ b/frontend/app/components/Register/index.js
@@ -52,6 +52,7 @@ export class Register extends Component {
     computeUserSelfregister: object.isRequired,
     splitWindowPath: array.isRequired,
     windowPath: string.isRequired,
+    intl: object.isRequired,
     // REDUX: actions/dispatch/func
     fetchDialect2: func.isRequired,
     pushWindowPath: func.isRequired,
@@ -74,7 +75,7 @@ export class Register extends Component {
   }
 
   fetchData(newProps) {
-    if (newProps.routeParams.hasOwnProperty('dialect_path')) {
+    if (Object.prototype.hasOwnProperty.call(newProps.routeParams, 'dialect_path')) {
       newProps.fetchDialect2(newProps.routeParams.dialect_path)
     }
   }
@@ -99,20 +100,20 @@ export class Register extends Component {
     }
 
     // 'Redirect' on success
-    if (selectn('success', currentWord) != selectn('success', nextWord) && selectn('success', nextWord) === true) {
+    if (selectn('success', currentWord) !== selectn('success', nextWord) && selectn('success', nextWord) === true) {
       //nextProps.replaceWindowPath('/' + nextProps.routeParams.siteTheme + selectn('response.path', nextWord).replace('Dictionary', 'learn/words'));
     }
   }
 
   shouldComponentUpdate(newProps /*, newState*/) {
     switch (true) {
-      case newProps.windowPath != this.props.windowPath:
+      case newProps.windowPath !== this.props.windowPath:
         return true
 
-      case newProps.computeDialect2 != this.props.computeDialect2:
+      case newProps.computeDialect2 !== this.props.computeDialect2:
         return true
 
-      case newProps.computeUserSelfregister != this.props.computeUserSelfregister:
+      case newProps.computeUserSelfregister !== this.props.computeUserSelfregister:
         return true
       default: // NOTE: do nothing
     }
@@ -129,7 +130,7 @@ export class Register extends Component {
     const properties = {}
 
     for (const key in formValue) {
-      if (formValue.hasOwnProperty(key) && key) {
+      if (Object.prototype.hasOwnProperty.call(formValue, key) && key) {
         if (formValue[key] && formValue[key] !== '') {
           properties[key] = formValue[key]
         }
@@ -277,7 +278,7 @@ export class Register extends Component {
                   onClick={this._onRequestSaveForm.bind(this, this.props.computeLogin)}
                   color="primary"
                 >
-                  <FVLabel transKey="register" defaultStr="Register" transform="first" />
+                  <FVLabel transKey="register" defaultStr="Register" />
                 </FVButton>
               </div>
             </form>

--- a/frontend/app_v2/index.html
+++ b/frontend/app_v2/index.html
@@ -3,6 +3,10 @@
 
 <head>
     <title>App V2</title>
+
+    <meta name="google-site-verification" content="EDJl0zb8mhsF1z_YbnEcdOwKF72uLcZw_3FGbSMVGSM" />
+    <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no">
+
     <!-- App V1 remoteEntry -->
     <script src="<%= V1_URL %>/assets/javascripts/remoteEntry.<%= COMMIT %>.js"></script>
 </head>

--- a/frontend/cypress_CI.json
+++ b/frontend/cypress_CI.json
@@ -10,5 +10,9 @@
   },
   "viewportHeight": 660,
   "viewportWidth": 1000,
-  "defaultCommandTimeout": 10000
+  "defaultCommandTimeout": 10000,
+  "retries": {
+    "runMode": 3,
+    "openMode": 0
+  }
 }


### PR DESCRIPTION
- Allow retries in Cypress (to allow for flaky tests)
- Fix label that was failing Cypress test
- Other changes to register.js are husky recommendations
- Added viewport meta tag for v2

#### Definition of Done
- [ ] Reviewer can follow the flow of the code
- [ ] Variables, methods are named properly and clearly
- [ ] Methods are documented using comments (where not self-explanatory)
- [ ] Any suggestions for refactoring have been implemented
- [ ] Tests are created and cover at least 85% of the functionality
- [ ] Code is unlikely to introduce new regressions
- [ ] Acceptance criteria has been met
